### PR TITLE
git config user.nameが未指定でもsetup.shが動作するように

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -31,11 +31,7 @@ n|N|no|NO)
   read -p 'docker image pullに必要なAuth情報を入力: ' HEADLESS_REGISTRY_AUTH
   ;;
 *)
-  DEFAULT_GITHUB_USER=""
-  if command -v git >/dev/null 2>&1; then
-    DEFAULT_GITHUB_USER="$(git config user.name)"
-  fi
-  if [ -n "${DEFAULT_GITHUB_USER}" ]; then
+  if command -v git >/dev/null 2>&1 && DEFAULT_GITHUB_USER="$(git config user.name)"; then
     read -p "image pullを行うGitHubのユーザー名を入力 (default: ${DEFAULT_GITHUB_USER}): " GHCR_USERNAME
     GHCR_USERNAME=${GHCR_USERNAME:-$DEFAULT_GITHUB_USER}
   else


### PR DESCRIPTION
https://github.com/hantabaru1014/baru-reso-headless-controller/blob/4db371b44ae789aa93c39c10239e79028b55e8d2/scripts/setup.sh#L36
ここで終了する

`git config user.name` が未設定の場合はexit-codeが1らしい

```bash
# git version
git version 2.39.5
# git config --global --unset user.name
# git config user.name
# echo $?
1
# A="$(git config user.name)"
# echo $?
1
```