### PR TITLE
feat: セッション詳細ページのちょっとした改修

### DIFF
--- a/front/src/components/HostTip.tsx
+++ b/front/src/components/HostTip.tsx
@@ -1,0 +1,22 @@
+import { useQuery } from "@connectrpc/connect-query";
+import { Skeleton } from "./ui";
+import { Link } from "react-router";
+import { getHeadlessHost } from "../../pbgen/hdlctrl/v1/controller-ControllerService_connectquery";
+
+export default function HostTip({ hostId }: { hostId?: string }) {
+  const { data, isPending } = useQuery(getHeadlessHost, {
+    hostId,
+  });
+
+  return (
+    <span>
+      {isPending ? (
+        <Skeleton className="h-4 w-32" />
+      ) : (
+        <Link to={`/hosts/${data?.host?.id}`} className="hover:underline">
+          {data?.host?.name} {`(${data?.host?.accountName})`}
+        </Link>
+      )}
+    </span>
+  );
+}

--- a/front/src/components/SessionForm.tsx
+++ b/front/src/components/SessionForm.tsx
@@ -33,6 +33,7 @@ import { formatTimestamp } from "../libs/datetimeUtils";
 import { toast } from "sonner";
 import { EditableTextArea, SplitButton } from "./base";
 import { AspectRatio, DropdownMenuItem } from "./ui";
+import HostTip from "./HostTip";
 
 const BOOL_SELECT_OPTIONS = [
   { id: "true", label: "はい", value: true },
@@ -271,7 +272,10 @@ export default function SessionForm({ sessionId }: { sessionId: string }) {
             </AspectRatio>
           </CardContent>
         </Card>
-        <div className="flex flex-col space-y-2">
+        <div className="flex flex-col space-y-1">
+          <span>
+            ホスト: <HostTip hostId={data?.session?.hostId} />
+          </span>
           <span>開始: {formatTimestamp(data?.session?.startedAt)}</span>
           {data?.session?.ownerId && (
             <span>オーナー: {data?.session?.ownerId}</span>

--- a/front/src/components/SessionForm.tsx
+++ b/front/src/components/SessionForm.tsx
@@ -256,7 +256,7 @@ export default function SessionForm({ sessionId }: { sessionId: string }) {
         </div>
         <Card className="h-full">
           <CardContent className="h-full">
-            <AspectRatio ratio={16 / 9}>
+            <AspectRatio ratio={2 / 1}>
               {sessionState?.thumbnailUrl ? (
                 <img
                   src={sessionState?.thumbnailUrl}


### PR DESCRIPTION
- [fix: サムネのアスペクト比を修正](https://github.com/hantabaru1014/baru-reso-headless-controller/commit/db9dcdb56eba41258ac7c4b4383ff99579ad24bd)
- [fix: ホストユーザーに対してinvalidな操作ボタンが出ないように修正](https://github.com/hantabaru1014/baru-reso-headless-controller/commit/279344e943b669e976d1feab9d0a6fb2b9191578)
- [feat: セッションのホストの表示を追加](https://github.com/hantabaru1014/baru-reso-headless-controller/commit/0f1e1a47abdb57d04343379b5a26030adb12d9bc)