### PR TITLE
feat: DataTable のカラム幅をドラッグで変更可能にする

### DIFF
--- a/front/src/components/base/DataTable.stories.tsx
+++ b/front/src/components/base/DataTable.stories.tsx
@@ -84,6 +84,9 @@ const meta = {
     loadingSkeletonCount: {
       control: "number",
     },
+    enableColumnResizing: {
+      control: "boolean",
+    },
   },
   args: {
     // @ts-expect-error なんかエラー出るけどとりあえず動くから無視
@@ -167,6 +170,28 @@ export const WithPaginationSinglePage: Story = {
         }}
       />
     );
+  },
+};
+
+/**
+ * ヘッダー右端の境界をマウスでドラッグするとカラム幅を変更できる。
+ * 初期状態はリサイズ無効時と同じく content による auto-sizing。
+ * `minSize` / `maxSize` を column 定義で指定するとドラッグ時の上下限を制限できる。
+ */
+export const ColumnResizing: Story = {
+  args: {
+    enableColumnResizing: true,
+  },
+  render: function Render(args) {
+    const data = useMemo(() => generateSampleData(8), []);
+    return <DataTable {...args} columns={columns} data={data} />;
+  },
+};
+
+/** `enableColumnResizing` を false にするとリサイズハンドルが消える。 */
+export const ColumnResizingDisabled: Story = {
+  args: {
+    enableColumnResizing: false,
   },
 };
 

--- a/front/src/components/base/DataTable.tsx
+++ b/front/src/components/base/DataTable.tsx
@@ -2,6 +2,7 @@ import {
   ColumnDef,
   flexRender,
   getCoreRowModel,
+  Header,
   useReactTable,
 } from "@tanstack/react-table";
 import {
@@ -14,6 +15,7 @@ import {
   TableRow,
 } from "../ui";
 import { DataTablePaginationBar } from "./DataTablePaginationBar";
+import { cn } from "@/libs/cssUtils";
 
 export type DataTablePaginationProps = {
   /** 0-based current page index */
@@ -32,6 +34,8 @@ interface DataTableProps<TData, TValue> {
   loadingSkeletonCount?: number;
   onClickRow?: (row: TData) => void;
   pagination?: DataTablePaginationProps;
+  /** ヘッダー右端をドラッグしてカラム幅を変更可能にする。デフォルト true。 */
+  enableColumnResizing?: boolean;
 }
 
 export function DataTable<TData, TValue>({
@@ -41,11 +45,13 @@ export function DataTable<TData, TValue>({
   loadingSkeletonCount = 5,
   onClickRow,
   pagination,
+  enableColumnResizing = true,
 }: DataTableProps<TData, TValue>) {
   const table = useReactTable({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
+    enableColumnResizing,
     ...(pagination
       ? {
           manualPagination: true,
@@ -63,6 +69,69 @@ export function DataTable<TData, TValue>({
       : {}),
   });
 
+  // 「リサイズされた」カラムだけ explicit width を持つ。未リサイズの列は content auto-sizing。
+  const columnSizing = table.getState().columnSizing;
+
+  const startResize = (
+    e: React.PointerEvent<HTMLDivElement>,
+    header: Header<TData, unknown>,
+  ) => {
+    if (e.button !== 0 && e.pointerType === "mouse") return;
+    const handle = e.currentTarget;
+    e.preventDefault();
+    e.stopPropagation();
+
+    // handle は th の直接の子なので parentElement は常に th
+    const startWidth = (
+      handle.parentElement as HTMLElement
+    ).getBoundingClientRect().width;
+    const startX = e.clientX;
+    const pointerId = e.pointerId;
+    const minSize = header.column.columnDef.minSize ?? 30;
+    const maxSize = header.column.columnDef.maxSize ?? Number.MAX_SAFE_INTEGER;
+
+    // setPointerCapture により pointermove/up は cursor が iframe 外に出ても確実にこのハンドルに届く
+    handle.setPointerCapture(pointerId);
+
+    table.setColumnSizing((prev) => ({
+      ...prev,
+      [header.column.id]: startWidth,
+    }));
+
+    const onMove = (moveEvent: PointerEvent) => {
+      const next = Math.min(
+        maxSize,
+        Math.max(minSize, startWidth + (moveEvent.clientX - startX)),
+      );
+      table.setColumnSizing((prev) => ({
+        ...prev,
+        [header.column.id]: next,
+      }));
+    };
+    const onEnd = () => {
+      handle.removeEventListener("pointermove", onMove);
+      handle.removeEventListener("pointerup", onEnd);
+      handle.removeEventListener("pointercancel", onEnd);
+      if (handle.hasPointerCapture(pointerId)) {
+        handle.releasePointerCapture(pointerId);
+      }
+      document.body.style.removeProperty("cursor");
+      document.body.style.removeProperty("user-select");
+    };
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    handle.addEventListener("pointermove", onMove);
+    handle.addEventListener("pointerup", onEnd);
+    handle.addEventListener("pointercancel", onEnd);
+  };
+
+  const widthStyle = (id: string): React.CSSProperties | undefined =>
+    columnSizing[id] !== undefined ? { width: columnSizing[id] } : undefined;
+
+  // 最終 leaf カラムは右に隣接列がないのでリサイズハンドルを出さない (慣例 & 横スクロール抑止)
+  const leafColumns = table.getVisibleLeafColumns();
+  const lastLeafColumnId = leafColumns[leafColumns.length - 1]?.id;
+
   return (
     <div className="space-y-4">
       <div className="rounded-md border">
@@ -72,13 +141,36 @@ export function DataTable<TData, TValue>({
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => {
                   return (
-                    <TableHead key={header.id}>
+                    <TableHead
+                      key={header.id}
+                      className="relative"
+                      style={widthStyle(header.column.id)}
+                    >
                       {header.isPlaceholder
                         ? null
                         : flexRender(
                             header.column.columnDef.header,
                             header.getContext(),
                           )}
+                      {enableColumnResizing &&
+                        header.column.getCanResize() &&
+                        header.column.id !== lastLeafColumnId && (
+                          <div
+                            onPointerDown={(e) => startResize(e, header)}
+                            onClick={(e) => e.stopPropagation()}
+                            className="group/resize absolute top-0 right-0 z-10 flex h-full w-3 translate-x-1/2 cursor-col-resize touch-none items-center justify-center select-none"
+                            aria-hidden
+                          >
+                            <div
+                              className={cn(
+                                "bg-border h-full w-px transition-opacity group-hover/resize:opacity-100",
+                                header.column.getIsResizing()
+                                  ? "bg-primary w-0.5 opacity-100"
+                                  : "opacity-0",
+                              )}
+                            />
+                          </div>
+                        )}
                     </TableHead>
                   );
                 })}
@@ -89,8 +181,11 @@ export function DataTable<TData, TValue>({
             {isLoading ? (
               Array.from({ length: loadingSkeletonCount }).map((_, index) => (
                 <TableRow key={`skeleton-${index}`}>
-                  {columns.map((_, colIndex) => (
-                    <TableCell key={`skeleton-cell-${index}-${colIndex}`}>
+                  {leafColumns.map((column, colIndex) => (
+                    <TableCell
+                      key={`skeleton-cell-${index}-${colIndex}`}
+                      style={widthStyle(column.id)}
+                    >
                       <Skeleton className="h-4 rounded" />
                     </TableCell>
                   ))}
@@ -105,7 +200,7 @@ export function DataTable<TData, TValue>({
                   className={onClickRow ? "cursor-pointer" : ""}
                 >
                   {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
+                    <TableCell key={cell.id} style={widthStyle(cell.column.id)}>
                       {flexRender(
                         cell.column.columnDef.cell,
                         cell.getContext(),


### PR DESCRIPTION
## Summary
- ヘッダー右端の境界をドラッグして列幅を変更できる機能を追加
- 未リサイズ列は content による auto-sizing、リサイズ済み列のみ explicit width を持つ
- Pointer Events + setPointerCapture でカーソルが iframe を出てもドラッグが破綻しない

## Test plan
- [x] Storybook の base/DataTable で各列の境界をドラッグしてリサイズできる
- [x] 連続して別の列をリサイズしても挙動が乱れない
- [x] enableColumnResizing=false でハンドルが表示されない
- [x] 横スクロールバーが出ない