### PR TITLE
feat: session ライフサイクルを host イベント購読で DB に反映する

### DIFF
--- a/adapter/session_repository.go
+++ b/adapter/session_repository.go
@@ -164,6 +164,39 @@ func (r *SessionRepository) ListByHostAndStatus(ctx context.Context, hostID stri
 	return result, nil
 }
 
+func (r *SessionRepository) InsertFromEvent(ctx context.Context, session *entity.Session) error {
+	// event 由来の session は startup_parameters を知らないため、nil の場合は
+	// 空 proto で埋める (sessions.startup_parameters の NOT NULL 制約を満たす)。
+	startupSource := session.StartupParameters
+	if startupSource == nil {
+		startupSource = &headlessv1.WorldStartupParameters{}
+	}
+
+	startupParams, err := protojson.Marshal(startupSource)
+	if err != nil {
+		return errors.Wrap(err, 0)
+	}
+
+	startedAt := pgtype.Timestamptz{Valid: session.StartedAt != nil}
+	if session.StartedAt != nil {
+		startedAt.Time = *session.StartedAt
+	}
+
+	if err := r.q.InsertSessionFromEvent(ctx, db.InsertSessionFromEventParams{
+		ID:                             session.ID,
+		Name:                           session.Name,
+		Status:                         int32(session.Status),
+		StartedAt:                      startedAt,
+		HostID:                         session.HostID,
+		StartupParameters:              startupParams,
+		StartupParametersSchemaVersion: 1,
+	}); err != nil {
+		return errors.WrapPrefix(convertDBErr(err), "session", 0)
+	}
+
+	return nil
+}
+
 func (r *SessionRepository) ApplySessionStarted(ctx context.Context, id, hostID, name string, occurredAt time.Time) (bool, error) {
 	rows, err := r.q.ApplySessionStarted(ctx, db.ApplySessionStartedParams{
 		ID:        id,
@@ -179,11 +212,12 @@ func (r *SessionRepository) ApplySessionStarted(ctx context.Context, id, hostID,
 	return rows > 0, nil
 }
 
-func (r *SessionRepository) ApplySessionEnded(ctx context.Context, id string, occurredAt time.Time) (bool, error) {
+func (r *SessionRepository) ApplySessionEnded(ctx context.Context, id, hostID string, occurredAt time.Time) (bool, error) {
 	rows, err := r.q.ApplySessionEnded(ctx, db.ApplySessionEndedParams{
 		ID:      id,
 		Status:  int32(entity.SessionStatus_ENDED),
 		EndedAt: pgtype.Timestamptz{Time: occurredAt, Valid: true},
+		HostID:  hostID,
 	})
 	if err != nil {
 		return false, errors.WrapPrefix(convertDBErr(err), "session", 0)

--- a/adapter/session_repository.go
+++ b/adapter/session_repository.go
@@ -141,6 +141,57 @@ func (r *SessionRepository) ListByStatus(ctx context.Context, status entity.Sess
 	return result, nil
 }
 
+func (r *SessionRepository) ListByHostAndStatus(ctx context.Context, hostID string, status entity.SessionStatus) (entity.SessionList, error) {
+	sessions, err := r.q.ListSessionsByHostAndStatus(ctx, db.ListSessionsByHostAndStatusParams{
+		HostID: hostID,
+		Status: int32(status),
+	})
+	if err != nil {
+		return nil, errors.WrapPrefix(convertDBErr(err), "session", 0)
+	}
+
+	result := make(entity.SessionList, 0, len(sessions))
+
+	for _, s := range sessions {
+		entity, err := sessionToEntity(s)
+		if err != nil {
+			return nil, errors.Wrap(err, 0)
+		}
+
+		result = append(result, entity)
+	}
+
+	return result, nil
+}
+
+func (r *SessionRepository) ApplySessionStarted(ctx context.Context, id, hostID, name string, occurredAt time.Time) (bool, error) {
+	rows, err := r.q.ApplySessionStarted(ctx, db.ApplySessionStartedParams{
+		ID:        id,
+		Name:      name,
+		Status:    int32(entity.SessionStatus_RUNNING),
+		StartedAt: pgtype.Timestamptz{Time: occurredAt, Valid: true},
+		HostID:    hostID,
+	})
+	if err != nil {
+		return false, errors.WrapPrefix(convertDBErr(err), "session", 0)
+	}
+
+	return rows > 0, nil
+}
+
+func (r *SessionRepository) ApplySessionEnded(ctx context.Context, id string, occurredAt time.Time) (bool, error) {
+	rows, err := r.q.ApplySessionEnded(ctx, db.ApplySessionEndedParams{
+		ID:      id,
+		Status:  int32(entity.SessionStatus_ENDED),
+		EndedAt: pgtype.Timestamptz{Time: occurredAt, Valid: true},
+	})
+	if err != nil {
+		return false, errors.WrapPrefix(convertDBErr(err), "session", 0)
+	}
+
+	return rows > 0, nil
+}
+
 func (r *SessionRepository) ListPaged(ctx context.Context, opts port.SessionListPageOptions) (*port.SessionListPageResult, error) {
 	params := db.ListSessionsPagedParams{
 		PageOffset: opts.PageIndex * opts.PageSize,

--- a/adapter/session_repository_test.go
+++ b/adapter/session_repository_test.go
@@ -1,0 +1,208 @@
+package adapter_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hantabaru1014/baru-reso-headless-controller/adapter"
+	"github.com/hantabaru1014/baru-reso-headless-controller/domain/entity"
+	"github.com/hantabaru1014/baru-reso-headless-controller/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSessionRepository_LifecycleQueries exercises the partial-update SQL
+// (ApplySessionStarted / ApplySessionEnded), the host_id+status list query,
+// and the ON CONFLICT DO NOTHING insert that back SessionLifecycleHandler.
+// The handler-level tests use an in-memory fake; this test verifies the
+// actual pgx/sqlc bindings, the WHERE clause logic, and the RowsAffected
+// behaviour of `:execrows` against a real Postgres.
+//
+// Requires the test database to be migrated (see `make test.setup`).
+func TestSessionRepository_LifecycleQueries(t *testing.T) {
+	queries, pool := testutil.SetupTestDB(t)
+
+	t.Run("ApplySessionStarted は新しい occurred_at で UPDATE する", func(t *testing.T) {
+		testutil.CleanupTables(t, pool)
+
+		repo := adapter.NewSessionRepository(queries)
+		host := testutil.CreateTestHeadlessHost(t, queries, "U-a", "host", entity.HeadlessHostStatus_RUNNING)
+		original := testutil.CreateTestSession(t, queries, host.ID, "session", entity.SessionStatus_RUNNING)
+
+		newStart := original.StartedAt.Time.Add(time.Hour)
+
+		applied, err := repo.ApplySessionStarted(t.Context(), original.ID, host.ID, "new-name", newStart)
+		require.NoError(t, err)
+		assert.True(t, applied, "newer occurred_at must report applied=true")
+
+		updated, err := repo.Get(t.Context(), original.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "new-name", updated.Name)
+		require.NotNil(t, updated.StartedAt)
+		assert.True(t, updated.StartedAt.Equal(newStart))
+		assert.Equal(t, entity.SessionStatus_RUNNING, updated.Status)
+		assert.Nil(t, updated.EndedAt, "ApplySessionStarted must clear ended_at")
+	})
+
+	t.Run("ApplySessionStarted は古い occurred_at を skip (RowsAffected==0)", func(t *testing.T) {
+		testutil.CleanupTables(t, pool)
+
+		repo := adapter.NewSessionRepository(queries)
+		host := testutil.CreateTestHeadlessHost(t, queries, "U-a", "host", entity.HeadlessHostStatus_RUNNING)
+		original := testutil.CreateTestSession(t, queries, host.ID, "session", entity.SessionStatus_RUNNING)
+
+		stale := original.StartedAt.Time.Add(-time.Hour)
+
+		applied, err := repo.ApplySessionStarted(t.Context(), original.ID, host.ID, "stale-name", stale)
+		require.NoError(t, err)
+		assert.False(t, applied, "older occurred_at must be skipped (RowsAffected==0)")
+
+		unchanged, err := repo.Get(t.Context(), original.ID)
+		require.NoError(t, err)
+		assert.Equal(t, original.Name, unchanged.Name, "stale event must not overwrite name")
+	})
+
+	t.Run("ApplySessionStarted は別 host を渡すと host_id を更新する", func(t *testing.T) {
+		testutil.CleanupTables(t, pool)
+
+		repo := adapter.NewSessionRepository(queries)
+		hostA := testutil.CreateTestHeadlessHost(t, queries, "U-a", "host-a", entity.HeadlessHostStatus_RUNNING)
+		hostB := testutil.CreateTestHeadlessHost(t, queries, "U-b", "host-b", entity.HeadlessHostStatus_RUNNING)
+
+		original := testutil.CreateTestSession(t, queries, hostA.ID, "session", entity.SessionStatus_RUNNING)
+		newStart := original.StartedAt.Time.Add(time.Hour)
+
+		applied, err := repo.ApplySessionStarted(t.Context(), original.ID, hostB.ID, "session", newStart)
+		require.NoError(t, err)
+		assert.True(t, applied)
+
+		updated, err := repo.Get(t.Context(), original.ID)
+		require.NoError(t, err)
+		assert.Equal(t, hostB.ID, updated.HostID, "ApplySessionStarted must allow host migration")
+	})
+
+	t.Run("ApplySessionEnded は新しい occurred_at で UPDATE する", func(t *testing.T) {
+		testutil.CleanupTables(t, pool)
+
+		repo := adapter.NewSessionRepository(queries)
+		host := testutil.CreateTestHeadlessHost(t, queries, "U-a", "host", entity.HeadlessHostStatus_RUNNING)
+		original := testutil.CreateTestSession(t, queries, host.ID, "session", entity.SessionStatus_RUNNING)
+		endedAt := original.StartedAt.Time.Add(2 * time.Hour)
+
+		applied, err := repo.ApplySessionEnded(t.Context(), original.ID, host.ID, endedAt)
+		require.NoError(t, err)
+		assert.True(t, applied)
+
+		updated, err := repo.Get(t.Context(), original.ID)
+		require.NoError(t, err)
+		assert.Equal(t, entity.SessionStatus_ENDED, updated.Status)
+		require.NotNil(t, updated.EndedAt)
+		assert.True(t, updated.EndedAt.Equal(endedAt))
+	})
+
+	t.Run("ApplySessionEnded は古い ended_at を skip", func(t *testing.T) {
+		testutil.CleanupTables(t, pool)
+
+		repo := adapter.NewSessionRepository(queries)
+		host := testutil.CreateTestHeadlessHost(t, queries, "U-a", "host", entity.HeadlessHostStatus_RUNNING)
+		original := testutil.CreateTestSession(t, queries, host.ID, "session", entity.SessionStatus_RUNNING)
+		firstEnd := original.StartedAt.Time.Add(2 * time.Hour)
+
+		_, err := repo.ApplySessionEnded(t.Context(), original.ID, host.ID, firstEnd)
+		require.NoError(t, err)
+
+		earlier := firstEnd.Add(-time.Hour)
+		applied, err := repo.ApplySessionEnded(t.Context(), original.ID, host.ID, earlier)
+		require.NoError(t, err)
+		assert.False(t, applied, "earlier occurred_at must be skipped (RowsAffected==0)")
+
+		got, err := repo.Get(t.Context(), original.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.EndedAt)
+		assert.True(t, got.EndedAt.Equal(firstEnd))
+	})
+
+	t.Run("ApplySessionEnded は host_id 不一致なら SQL レベルで skip", func(t *testing.T) {
+		testutil.CleanupTables(t, pool)
+
+		repo := adapter.NewSessionRepository(queries)
+		hostA := testutil.CreateTestHeadlessHost(t, queries, "U-a", "host-a", entity.HeadlessHostStatus_RUNNING)
+		hostB := testutil.CreateTestHeadlessHost(t, queries, "U-b", "host-b", entity.HeadlessHostStatus_RUNNING)
+
+		original := testutil.CreateTestSession(t, queries, hostA.ID, "session", entity.SessionStatus_RUNNING)
+		endedAt := original.StartedAt.Time.Add(2 * time.Hour)
+
+		applied, err := repo.ApplySessionEnded(t.Context(), original.ID, hostB.ID, endedAt)
+		require.NoError(t, err)
+		assert.False(t, applied,
+			"SessionEnded from a non-owning host must be skipped at the SQL level")
+
+		got, err := repo.Get(t.Context(), original.ID)
+		require.NoError(t, err)
+		assert.Equal(t, entity.SessionStatus_RUNNING, got.Status)
+		assert.Nil(t, got.EndedAt)
+	})
+
+	t.Run("InsertFromEvent は既存 row を上書きしない (ON CONFLICT DO NOTHING)", func(t *testing.T) {
+		testutil.CleanupTables(t, pool)
+
+		repo := adapter.NewSessionRepository(queries)
+		host := testutil.CreateTestHeadlessHost(t, queries, "U-a", "host", entity.HeadlessHostStatus_RUNNING)
+		original := testutil.CreateTestSession(t, queries, host.ID, "original-name", entity.SessionStatus_RUNNING)
+
+		newStart := original.StartedAt.Time.Add(time.Hour)
+		err := repo.InsertFromEvent(t.Context(), &entity.Session{
+			ID:        original.ID,
+			Name:      "conflicting-name",
+			Status:    entity.SessionStatus_RUNNING,
+			HostID:    host.ID,
+			StartedAt: &newStart,
+		})
+		require.NoError(t, err)
+
+		got, err := repo.Get(t.Context(), original.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "original-name", got.Name, "InsertFromEvent must not overwrite an existing row")
+	})
+
+	t.Run("InsertFromEvent は新しい id なら row を作る", func(t *testing.T) {
+		testutil.CleanupTables(t, pool)
+
+		repo := adapter.NewSessionRepository(queries)
+		host := testutil.CreateTestHeadlessHost(t, queries, "U-a", "host", entity.HeadlessHostStatus_RUNNING)
+
+		now := time.Now().UTC().Truncate(time.Microsecond)
+		err := repo.InsertFromEvent(t.Context(), &entity.Session{
+			ID:        "fresh-session-id",
+			Name:      "fresh-name",
+			Status:    entity.SessionStatus_RUNNING,
+			HostID:    host.ID,
+			StartedAt: &now,
+		})
+		require.NoError(t, err)
+
+		got, err := repo.Get(t.Context(), "fresh-session-id")
+		require.NoError(t, err)
+		assert.Equal(t, "fresh-name", got.Name)
+		assert.Equal(t, host.ID, got.HostID)
+		assert.Equal(t, entity.SessionStatus_RUNNING, got.Status)
+	})
+
+	t.Run("ListByHostAndStatus は host_id と status の両方で絞り込む", func(t *testing.T) {
+		testutil.CleanupTables(t, pool)
+
+		repo := adapter.NewSessionRepository(queries)
+		hostA := testutil.CreateTestHeadlessHost(t, queries, "U-a", "host-a", entity.HeadlessHostStatus_RUNNING)
+		hostB := testutil.CreateTestHeadlessHost(t, queries, "U-b", "host-b", entity.HeadlessHostStatus_RUNNING)
+
+		wantRunning := testutil.CreateTestSession(t, queries, hostA.ID, "wanted", entity.SessionStatus_RUNNING)
+		_ = testutil.CreateTestSession(t, queries, hostA.ID, "ended-same-host", entity.SessionStatus_ENDED)
+		_ = testutil.CreateTestSession(t, queries, hostA.ID, "starting-same-host", entity.SessionStatus_STARTING)
+		_ = testutil.CreateTestSession(t, queries, hostB.ID, "running-other-host", entity.SessionStatus_RUNNING)
+
+		got, err := repo.ListByHostAndStatus(t.Context(), hostA.ID, entity.SessionStatus_RUNNING)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, wantRunning.ID, got[0].ID)
+	})
+}

--- a/app/wire.go
+++ b/app/wire.go
@@ -62,12 +62,12 @@ func ProvideWorkerRunners(
 }
 
 // ProvideHostEventHandlers gathers consumers for the per-host event
-// streams. Today only a logging handler is registered; add real handlers
-// here as they come online.
+// streams.
 func ProvideHostEventHandlers(
 	loggingHandler *worker.LoggingHostEventHandler,
+	sessionLifecycleHandler *worker.SessionLifecycleHandler,
 ) []worker.HostEventHandler {
-	return []worker.HostEventHandler{loggingHandler}
+	return []worker.HostEventHandler{loggingHandler, sessionLifecycleHandler}
 }
 
 var ConfigSet = wire.NewSet(
@@ -113,6 +113,7 @@ func InitializeServer(cfg *config.EnvConfig) (*Server, error) {
 		worker.NewSQLHostEventStore,
 		wire.Bind(new(worker.HostEventStore), new(*worker.SQLHostEventStore)),
 		worker.NewLoggingHostEventHandler,
+		worker.NewSessionLifecycleHandler,
 		ProvideHostEventHandlers,
 		ProvideWorkerRunners,
 		worker.NewManager,

--- a/app/wire_gen.go
+++ b/app/wire_gen.go
@@ -50,7 +50,8 @@ func InitializeServer(cfg *config.EnvConfig) (*Server, error) {
 	dockerEventWatcher := worker.NewDockerEventWatcher(dockerHostConnector, queries, workerConfig)
 	sqlHostEventStore := worker.NewSQLHostEventStore(queries)
 	loggingHostEventHandler := worker.NewLoggingHostEventHandler()
-	v := ProvideHostEventHandlers(loggingHostEventHandler)
+	sessionLifecycleHandler := worker.NewSessionLifecycleHandler(sessionRepository)
+	v := ProvideHostEventHandlers(loggingHostEventHandler, sessionLifecycleHandler)
 	hostEventWatcher := worker.NewHostEventWatcher(headlessHostRepository, sqlHostEventStore, workerConfig, v)
 	v2 := ProvideWorkerRunners(imageChecker, dockerEventWatcher, hostEventWatcher)
 	manager := worker.NewManager(v2)
@@ -125,12 +126,12 @@ func ProvideWorkerRunners(
 }
 
 // ProvideHostEventHandlers gathers consumers for the per-host event
-// streams. Today only a logging handler is registered; add real handlers
-// here as they come online.
+// streams.
 func ProvideHostEventHandlers(
 	loggingHandler *worker.LoggingHostEventHandler,
+	sessionLifecycleHandler *worker.SessionLifecycleHandler,
 ) []worker.HostEventHandler {
-	return []worker.HostEventHandler{loggingHandler}
+	return []worker.HostEventHandler{loggingHandler, sessionLifecycleHandler}
 }
 
 var ConfigSet = wire.NewSet(

--- a/db/migrations/20260627070032_add_sessions_host_status_index.down.sql
+++ b/db/migrations/20260627070032_add_sessions_host_status_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS sessions_host_id_status_idx;

--- a/db/migrations/20260627070032_add_sessions_host_status_index.up.sql
+++ b/db/migrations/20260627070032_add_sessions_host_status_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS sessions_host_id_status_idx ON sessions(host_id, status);

--- a/db/queries/sessions.sql
+++ b/db/queries/sessions.sql
@@ -38,6 +38,33 @@ SELECT * FROM sessions ORDER BY started_at DESC;
 -- name: ListSessionsByStatus :many
 SELECT * FROM sessions WHERE status = $1 ORDER BY started_at DESC;
 
+-- name: ListSessionsByHostAndStatus :many
+SELECT * FROM sessions WHERE host_id = $1 AND status = $2 ORDER BY started_at DESC;
+
+-- name: ApplySessionStarted :execrows
+-- host から届く SessionStarted を反映する部分更新。
+-- occurred_at が現在の started_at より新しい場合のみ更新する (idempotent / 巻き戻し防止)。
+-- 他フィールド (memo, auto_upgrade, startup_parameters, owner_id 等) には触れない。
+UPDATE sessions
+SET
+    name = $2,
+    status = $3,
+    started_at = $4,
+    ended_at = NULL,
+    host_id = $5
+WHERE id = $1
+  AND (started_at IS NULL OR started_at < $4);
+
+-- name: ApplySessionEnded :execrows
+-- host から届く SessionEnded を反映する部分更新。
+-- occurred_at が現在の ended_at より新しい場合のみ更新する。
+UPDATE sessions
+SET
+    status = $2,
+    ended_at = $3
+WHERE id = $1
+  AND (ended_at IS NULL OR ended_at < $3);
+
 -- name: ListSessionsPaged :many
 -- ページング付きセッション一覧。
 -- status / host_id は nullable パラメータ (sqlc.narg)。NULL なら未指定として扱う。

--- a/db/queries/sessions.sql
+++ b/db/queries/sessions.sql
@@ -58,12 +58,34 @@ WHERE id = $1
 -- name: ApplySessionEnded :execrows
 -- host から届く SessionEnded を反映する部分更新。
 -- occurred_at が現在の ended_at より新しい場合のみ更新する。
+-- host_id 一致条件で、host 移動後に旧 host から遅延配信された SessionEnded
+-- が現所有 host の session を倒すのを SQL レベルでも防ぐ。
 UPDATE sessions
 SET
     status = $2,
     ended_at = $3
 WHERE id = $1
+  AND host_id = $4
   AND (ended_at IS NULL OR ended_at < $3);
+
+-- name: InsertSessionFromEvent :exec
+-- host 由来の SessionStarted で「DB に存在しない session」を作る用の挿入。
+-- ON CONFLICT DO NOTHING にすることで、competing path (SessionUsecase.StartSession など)
+-- が同 id で先に row を作っていた場合に memo / owner_id / startup_parameters 等を
+-- 上書きしないことを保証する (handler は続けて ApplySessionStarted で部分更新する)。
+INSERT INTO sessions (
+    id,
+    name,
+    status,
+    started_at,
+    host_id,
+    startup_parameters,
+    startup_parameters_schema_version,
+    auto_upgrade
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, FALSE
+)
+ON CONFLICT (id) DO NOTHING;
 
 -- name: ListSessionsPaged :many
 -- ページング付きセッション一覧。

--- a/db/sessions.sql.go
+++ b/db/sessions.sql.go
@@ -17,6 +17,7 @@ SET
     status = $2,
     ended_at = $3
 WHERE id = $1
+  AND host_id = $4
   AND (ended_at IS NULL OR ended_at < $3)
 `
 
@@ -24,12 +25,20 @@ type ApplySessionEndedParams struct {
 	ID      string
 	Status  int32
 	EndedAt pgtype.Timestamptz
+	HostID  string
 }
 
 // host から届く SessionEnded を反映する部分更新。
 // occurred_at が現在の ended_at より新しい場合のみ更新する。
+// host_id 一致条件で、host 移動後に旧 host から遅延配信された SessionEnded
+// が現所有 host の session を倒すのを SQL レベルでも防ぐ。
 func (q *Queries) ApplySessionEnded(ctx context.Context, arg ApplySessionEndedParams) (int64, error) {
-	result, err := q.db.Exec(ctx, applySessionEnded, arg.ID, arg.Status, arg.EndedAt)
+	result, err := q.db.Exec(ctx, applySessionEnded,
+		arg.ID,
+		arg.Status,
+		arg.EndedAt,
+		arg.HostID,
+	)
 	if err != nil {
 		return 0, err
 	}
@@ -105,6 +114,49 @@ func (q *Queries) GetSession(ctx context.Context, id string) (Session, error) {
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const insertSessionFromEvent = `-- name: InsertSessionFromEvent :exec
+INSERT INTO sessions (
+    id,
+    name,
+    status,
+    started_at,
+    host_id,
+    startup_parameters,
+    startup_parameters_schema_version,
+    auto_upgrade
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, FALSE
+)
+ON CONFLICT (id) DO NOTHING
+`
+
+type InsertSessionFromEventParams struct {
+	ID                             string
+	Name                           string
+	Status                         int32
+	StartedAt                      pgtype.Timestamptz
+	HostID                         string
+	StartupParameters              []byte
+	StartupParametersSchemaVersion int32
+}
+
+// host 由来の SessionStarted で「DB に存在しない session」を作る用の挿入。
+// ON CONFLICT DO NOTHING にすることで、competing path (SessionUsecase.StartSession など)
+// が同 id で先に row を作っていた場合に memo / owner_id / startup_parameters 等を
+// 上書きしないことを保証する (handler は続けて ApplySessionStarted で部分更新する)。
+func (q *Queries) InsertSessionFromEvent(ctx context.Context, arg InsertSessionFromEventParams) error {
+	_, err := q.db.Exec(ctx, insertSessionFromEvent,
+		arg.ID,
+		arg.Name,
+		arg.Status,
+		arg.StartedAt,
+		arg.HostID,
+		arg.StartupParameters,
+		arg.StartupParametersSchemaVersion,
+	)
+	return err
 }
 
 const listSessions = `-- name: ListSessions :many

--- a/db/sessions.sql.go
+++ b/db/sessions.sql.go
@@ -11,6 +11,68 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const applySessionEnded = `-- name: ApplySessionEnded :execrows
+UPDATE sessions
+SET
+    status = $2,
+    ended_at = $3
+WHERE id = $1
+  AND (ended_at IS NULL OR ended_at < $3)
+`
+
+type ApplySessionEndedParams struct {
+	ID      string
+	Status  int32
+	EndedAt pgtype.Timestamptz
+}
+
+// host から届く SessionEnded を反映する部分更新。
+// occurred_at が現在の ended_at より新しい場合のみ更新する。
+func (q *Queries) ApplySessionEnded(ctx context.Context, arg ApplySessionEndedParams) (int64, error) {
+	result, err := q.db.Exec(ctx, applySessionEnded, arg.ID, arg.Status, arg.EndedAt)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const applySessionStarted = `-- name: ApplySessionStarted :execrows
+UPDATE sessions
+SET
+    name = $2,
+    status = $3,
+    started_at = $4,
+    ended_at = NULL,
+    host_id = $5
+WHERE id = $1
+  AND (started_at IS NULL OR started_at < $4)
+`
+
+type ApplySessionStartedParams struct {
+	ID        string
+	Name      string
+	Status    int32
+	StartedAt pgtype.Timestamptz
+	HostID    string
+}
+
+// host から届く SessionStarted を反映する部分更新。
+// occurred_at が現在の started_at より新しい場合のみ更新する (idempotent / 巻き戻し防止)。
+// 他フィールド (memo, auto_upgrade, startup_parameters, owner_id 等) には触れない。
+func (q *Queries) ApplySessionStarted(ctx context.Context, arg ApplySessionStartedParams) (int64, error) {
+	result, err := q.db.Exec(ctx, applySessionStarted,
+		arg.ID,
+		arg.Name,
+		arg.Status,
+		arg.StartedAt,
+		arg.HostID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const deleteSession = `-- name: DeleteSession :exec
 DELETE FROM sessions WHERE id = $1
 `
@@ -51,6 +113,49 @@ SELECT id, name, status, started_at, owner_id, ended_at, host_id, startup_parame
 
 func (q *Queries) ListSessions(ctx context.Context) ([]Session, error) {
 	rows, err := q.db.Query(ctx, listSessions)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Session
+	for rows.Next() {
+		var i Session
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Status,
+			&i.StartedAt,
+			&i.OwnerID,
+			&i.EndedAt,
+			&i.HostID,
+			&i.StartupParameters,
+			&i.StartupParametersSchemaVersion,
+			&i.AutoUpgrade,
+			&i.Memo,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listSessionsByHostAndStatus = `-- name: ListSessionsByHostAndStatus :many
+SELECT id, name, status, started_at, owner_id, ended_at, host_id, startup_parameters, startup_parameters_schema_version, auto_upgrade, memo, created_at, updated_at FROM sessions WHERE host_id = $1 AND status = $2 ORDER BY started_at DESC
+`
+
+type ListSessionsByHostAndStatusParams struct {
+	HostID string
+	Status int32
+}
+
+func (q *Queries) ListSessionsByHostAndStatus(ctx context.Context, arg ListSessionsByHostAndStatusParams) ([]Session, error) {
+	rows, err := q.db.Query(ctx, listSessionsByHostAndStatus, arg.HostID, arg.Status)
 	if err != nil {
 		return nil, err
 	}

--- a/usecase/port/session_repository.go
+++ b/usecase/port/session_repository.go
@@ -29,6 +29,11 @@ type SessionRepository interface {
 	ListPaged(ctx context.Context, opts SessionListPageOptions) (*SessionListPageResult, error)
 	Delete(ctx context.Context, id string) error
 
+	// InsertFromEvent は host 由来の SessionStarted で「DB に存在しない session」を
+	// 作るための ON CONFLICT DO NOTHING な INSERT。競合 path (SessionUsecase.StartSession 等)
+	// が先に row を作っていた場合は何もしない (handler 側で続けて ApplySessionStarted を
+	// 呼ぶ前提)。
+	InsertFromEvent(ctx context.Context, session *entity.Session) error
 	// ApplySessionStarted は host 由来の SessionStarted を反映する部分更新。
 	// occurred_at が現在の started_at より新しい場合のみ status/started_at/ended_at/name/host_id を更新する。
 	// 更新が実際に行われた場合は true を返す (skip された場合は false)。
@@ -36,5 +41,7 @@ type SessionRepository interface {
 	ApplySessionStarted(ctx context.Context, id, hostID, name string, occurredAt time.Time) (bool, error)
 	// ApplySessionEnded は host 由来の SessionEnded を反映する部分更新。
 	// occurred_at が現在の ended_at より新しい場合のみ status/ended_at を更新する。
-	ApplySessionEnded(ctx context.Context, id string, occurredAt time.Time) (bool, error)
+	// hostID が現所有 host と一致する場合のみ反映 (旧 host から遅延配信された
+	// SessionEnded で現所有 host の session を倒さないようにする)。
+	ApplySessionEnded(ctx context.Context, id, hostID string, occurredAt time.Time) (bool, error)
 }

--- a/usecase/port/session_repository.go
+++ b/usecase/port/session_repository.go
@@ -2,6 +2,7 @@ package port
 
 import (
 	"context"
+	"time"
 
 	"github.com/hantabaru1014/baru-reso-headless-controller/domain/entity"
 )
@@ -24,6 +25,16 @@ type SessionRepository interface {
 	Get(ctx context.Context, id string) (*entity.Session, error)
 	ListAll(ctx context.Context) (entity.SessionList, error)
 	ListByStatus(ctx context.Context, status entity.SessionStatus) (entity.SessionList, error)
+	ListByHostAndStatus(ctx context.Context, hostID string, status entity.SessionStatus) (entity.SessionList, error)
 	ListPaged(ctx context.Context, opts SessionListPageOptions) (*SessionListPageResult, error)
 	Delete(ctx context.Context, id string) error
+
+	// ApplySessionStarted は host 由来の SessionStarted を反映する部分更新。
+	// occurred_at が現在の started_at より新しい場合のみ status/started_at/ended_at/name/host_id を更新する。
+	// 更新が実際に行われた場合は true を返す (skip された場合は false)。
+	// memo / auto_upgrade / startup_parameters / owner_id 等他フィールドには触れない。
+	ApplySessionStarted(ctx context.Context, id, hostID, name string, occurredAt time.Time) (bool, error)
+	// ApplySessionEnded は host 由来の SessionEnded を反映する部分更新。
+	// occurred_at が現在の ended_at より新しい場合のみ status/ended_at を更新する。
+	ApplySessionEnded(ctx context.Context, id string, occurredAt time.Time) (bool, error)
 }

--- a/worker/session_lifecycle_handler.go
+++ b/worker/session_lifecycle_handler.go
@@ -28,6 +28,13 @@ func NewSessionLifecycleHandler(sessionRepo port.SessionRepository) *SessionLife
 var _ HostEventHandler = (*SessionLifecycleHandler)(nil)
 
 func (h *SessionLifecycleHandler) HandleHostEvent(ctx context.Context, hostID string, ev *headlessv1.HostEvent) {
+	if ev.GetOccurredAt() == nil {
+		slog.Warn("session-lifecycle: dropping event with missing occurred_at",
+			"hostID", hostID, "eventID", ev.GetId())
+
+		return
+	}
+
 	occurredAt := ev.GetOccurredAt().AsTime()
 
 	switch payload := ev.GetPayload().(type) {
@@ -70,38 +77,28 @@ func (h *SessionLifecycleHandler) handleSessionStarted(ctx context.Context, host
 	sessionID := payload.GetSessionId()
 	logArgs := []any{"hostID", hostID, "eventID", eventID, "sessionID", sessionID}
 
-	existing, err := h.sessionRepo.Get(ctx, sessionID)
-
-	switch {
-	case errors.Is(err, domain.ErrNotFound):
-		// host 側で UI などから直接 world が起動された (controller を経由していない)。
-		// startup_parameters は NOT NULL なので空 proto で埋める。
-		newSession := &entity.Session{
-			ID:                sessionID,
-			Name:              payload.GetSessionName(),
-			Status:            entity.SessionStatus_RUNNING,
-			HostID:            hostID,
-			StartedAt:         &occurredAt,
-			StartupParameters: &headlessv1.WorldStartupParameters{},
-		}
-		if err := h.sessionRepo.Upsert(ctx, newSession); err != nil {
-			slog.Error("session-lifecycle: failed to create session from SessionStarted",
-				append(logArgs, "error", err)...)
-		}
-
-		return
-	case err != nil:
-		slog.Error("session-lifecycle: failed to load session for SessionStarted",
+	// 競合 path (SessionUsecase.StartSession 等) と race にならないよう、
+	// 「未存在なら作る」と「部分更新」を分離して両方無条件に呼ぶ:
+	//   1. InsertFromEvent は ON CONFLICT DO NOTHING なので、既に row があれば
+	//      何もせず memo / owner_id / startup_parameters を壊さない。
+	//   2. ApplySessionStarted は started_at < occurred_at 条件で部分 UPDATE。
+	//      新しい event なら name/status/started_at/ended_at/host_id だけ反映、
+	//      古い event なら no-op。
+	// この順序なら「先に何が書かれたか問わず、最終状態は SessionStarted が
+	// 反映され、かつ無関係なフィールドは保持される」が成立。
+	newSession := &entity.Session{
+		ID:                sessionID,
+		Name:              payload.GetSessionName(),
+		Status:            entity.SessionStatus_RUNNING,
+		HostID:            hostID,
+		StartedAt:         &occurredAt,
+		StartupParameters: &headlessv1.WorldStartupParameters{},
+	}
+	if err := h.sessionRepo.InsertFromEvent(ctx, newSession); err != nil {
+		slog.Error("session-lifecycle: failed to insert session from SessionStarted",
 			append(logArgs, "error", err)...)
 
 		return
-	}
-
-	if existing.HostID != hostID {
-		// SessionStarted は新しい host から来ているはずなので、host 移動とみなして
-		// 受け入れる (ApplySessionStarted が host_id も更新する)。
-		slog.Info("session-lifecycle: session migrated to a different host",
-			append(logArgs, "previousHostID", existing.HostID)...)
 	}
 
 	applied, err := h.sessionRepo.ApplySessionStarted(ctx, sessionID, hostID, payload.GetSessionName(), occurredAt)
@@ -138,7 +135,7 @@ func (h *SessionLifecycleHandler) handleSessionEnded(ctx context.Context, hostID
 
 	if existing.HostID != hostID {
 		// 古い host から遅延配信された SessionEnded で現所有 host の session を
-		// 倒さないようにスキップする。
+		// 倒さないようにスキップする (SQL の host_id 一致条件と二重防御)。
 		slog.Warn("session-lifecycle: SessionEnded from non-owning host; skipping",
 			append(logArgs, "ownerHostID", existing.HostID)...)
 
@@ -152,7 +149,7 @@ func (h *SessionLifecycleHandler) handleSessionEnded(ctx context.Context, hostID
 		return
 	}
 
-	applied, err := h.sessionRepo.ApplySessionEnded(ctx, sessionID, occurredAt)
+	applied, err := h.sessionRepo.ApplySessionEnded(ctx, sessionID, hostID, occurredAt)
 	if err != nil {
 		slog.Error("session-lifecycle: failed to apply SessionEnded",
 			append(logArgs, "error", err)...)

--- a/worker/session_lifecycle_handler.go
+++ b/worker/session_lifecycle_handler.go
@@ -12,11 +12,11 @@ import (
 	"github.com/hantabaru1014/baru-reso-headless-controller/usecase/port"
 )
 
-// SessionLifecycleHandler keeps the sessions table in sync with the
-// SessionStarted / SessionEnded events emitted by each headless host so
-// that container-internal restarts (auto recover, world restart, ...)
-// are reflected in the DB without going through a controller-side
-// StartSession call.
+// SessionLifecycleHandler は host から届く SessionStarted / SessionEnded を
+// sessions テーブルに idempotent に反映する HostEventHandler。
+// controller 経由の StartSession 由来か、container 内部の auto recover や
+// world restart 由来か、host UI からの直接起動由来かに関係なく、同じ経路で
+// started_at / ended_at / status を最新化する。
 type SessionLifecycleHandler struct {
 	sessionRepo port.SessionRepository
 }
@@ -34,11 +34,37 @@ func (h *SessionLifecycleHandler) HandleHostEvent(ctx context.Context, hostID st
 	case *headlessv1.HostEvent_SessionStarted:
 		h.handleSessionStarted(ctx, hostID, ev.GetId(), occurredAt, payload.SessionStarted)
 	case *headlessv1.HostEvent_SessionEnded:
-		h.handleSessionEnded(ctx, ev.GetId(), occurredAt, payload.SessionEnded)
+		h.handleSessionEnded(ctx, hostID, ev.GetId(), occurredAt, payload.SessionEnded)
 	}
 }
 
-func (h *SessionLifecycleHandler) HandleHostEventStreamReset(_ context.Context, _ string) {}
+// HandleHostEventStreamReset は OutOfRange でストリームが切れた直後に呼ばれる。
+// 切れている間に SessionEnded を取りこぼした可能性があるため、当該 host で
+// RUNNING になっている session を一旦 UNKNOWN に倒す。次の SessionStarted や
+// 他の resync 経路で正しい状態に戻る想定の最弱の防衛。
+func (h *SessionLifecycleHandler) HandleHostEventStreamReset(ctx context.Context, hostID string) {
+	sessions, err := h.sessionRepo.ListByHostAndStatus(ctx, hostID, entity.SessionStatus_RUNNING)
+	if err != nil {
+		slog.Error("session-lifecycle: failed to list RUNNING sessions on stream reset",
+			"hostID", hostID, "error", err)
+
+		return
+	}
+
+	if len(sessions) == 0 {
+		return
+	}
+
+	for _, s := range sessions {
+		if err := h.sessionRepo.UpdateStatus(ctx, s.ID, entity.SessionStatus_UNKNOWN); err != nil {
+			slog.Error("session-lifecycle: failed to demote session on stream reset",
+				"hostID", hostID, "sessionID", s.ID, "error", err)
+		}
+	}
+
+	slog.Warn("session-lifecycle: demoted RUNNING sessions to UNKNOWN due to host event stream reset",
+		"hostID", hostID, "count", len(sessions))
+}
 
 func (h *SessionLifecycleHandler) handleSessionStarted(ctx context.Context, hostID, eventID string, occurredAt time.Time, payload *headlessv1.SessionStarted) {
 	sessionID := payload.GetSessionId()
@@ -48,36 +74,53 @@ func (h *SessionLifecycleHandler) handleSessionStarted(ctx context.Context, host
 
 	switch {
 	case errors.Is(err, domain.ErrNotFound):
-		existing = &entity.Session{
-			ID:     sessionID,
-			HostID: hostID,
+		// host 側で UI などから直接 world が起動された (controller を経由していない)。
+		// startup_parameters は NOT NULL なので空 proto で埋める。
+		newSession := &entity.Session{
+			ID:                sessionID,
+			Name:              payload.GetSessionName(),
+			Status:            entity.SessionStatus_RUNNING,
+			HostID:            hostID,
+			StartedAt:         &occurredAt,
+			StartupParameters: &headlessv1.WorldStartupParameters{},
 		}
+		if err := h.sessionRepo.Upsert(ctx, newSession); err != nil {
+			slog.Error("session-lifecycle: failed to create session from SessionStarted",
+				append(logArgs, "error", err)...)
+		}
+
+		return
 	case err != nil:
 		slog.Error("session-lifecycle: failed to load session for SessionStarted",
 			append(logArgs, "error", err)...)
 
 		return
-	case existing.StartedAt != nil && !occurredAt.After(*existing.StartedAt):
-		slog.Debug("session-lifecycle: SessionStarted occurred_at is not newer than stored started_at; skipping",
-			append(logArgs, "occurredAt", occurredAt, "storedStartedAt", *existing.StartedAt)...)
+	}
+
+	if existing.HostID != hostID {
+		// SessionStarted は新しい host から来ているはずなので、host 移動とみなして
+		// 受け入れる (ApplySessionStarted が host_id も更新する)。
+		slog.Info("session-lifecycle: session migrated to a different host",
+			append(logArgs, "previousHostID", existing.HostID)...)
+	}
+
+	applied, err := h.sessionRepo.ApplySessionStarted(ctx, sessionID, hostID, payload.GetSessionName(), occurredAt)
+	if err != nil {
+		slog.Error("session-lifecycle: failed to apply SessionStarted",
+			append(logArgs, "error", err)...)
 
 		return
 	}
 
-	existing.Name = payload.GetSessionName()
-	existing.Status = entity.SessionStatus_RUNNING
-	existing.StartedAt = &occurredAt
-	existing.EndedAt = nil
-
-	if err := h.sessionRepo.Upsert(ctx, existing); err != nil {
-		slog.Error("session-lifecycle: failed to upsert session from SessionStarted",
-			append(logArgs, "error", err)...)
+	if !applied {
+		slog.Debug("session-lifecycle: SessionStarted occurred_at is not newer than stored started_at; skipped",
+			append(logArgs, "occurredAt", occurredAt)...)
 	}
 }
 
-func (h *SessionLifecycleHandler) handleSessionEnded(ctx context.Context, eventID string, occurredAt time.Time, payload *headlessv1.SessionEnded) {
+func (h *SessionLifecycleHandler) handleSessionEnded(ctx context.Context, hostID, eventID string, occurredAt time.Time, payload *headlessv1.SessionEnded) {
 	sessionID := payload.GetSessionId()
-	logArgs := []any{"eventID", eventID, "sessionID", sessionID}
+	logArgs := []any{"hostID", hostID, "eventID", eventID, "sessionID", sessionID}
 
 	existing, err := h.sessionRepo.Get(ctx, sessionID)
 
@@ -91,18 +134,34 @@ func (h *SessionLifecycleHandler) handleSessionEnded(ctx context.Context, eventI
 			append(logArgs, "error", err)...)
 
 		return
-	case existing.EndedAt != nil && !occurredAt.After(*existing.EndedAt):
-		slog.Debug("session-lifecycle: SessionEnded occurred_at is not newer than stored ended_at; skipping",
-			append(logArgs, "occurredAt", occurredAt, "storedEndedAt", *existing.EndedAt)...)
+	}
+
+	if existing.HostID != hostID {
+		// 古い host から遅延配信された SessionEnded で現所有 host の session を
+		// 倒さないようにスキップする。
+		slog.Warn("session-lifecycle: SessionEnded from non-owning host; skipping",
+			append(logArgs, "ownerHostID", existing.HostID)...)
 
 		return
 	}
 
-	existing.Status = entity.SessionStatus_ENDED
-	existing.EndedAt = &occurredAt
+	if existing.StartedAt != nil && occurredAt.Before(*existing.StartedAt) {
+		slog.Warn("session-lifecycle: SessionEnded occurred_at predates started_at; skipping",
+			append(logArgs, "occurredAt", occurredAt, "storedStartedAt", *existing.StartedAt)...)
 
-	if err := h.sessionRepo.Upsert(ctx, existing); err != nil {
-		slog.Error("session-lifecycle: failed to upsert session from SessionEnded",
+		return
+	}
+
+	applied, err := h.sessionRepo.ApplySessionEnded(ctx, sessionID, occurredAt)
+	if err != nil {
+		slog.Error("session-lifecycle: failed to apply SessionEnded",
 			append(logArgs, "error", err)...)
+
+		return
+	}
+
+	if !applied {
+		slog.Debug("session-lifecycle: SessionEnded occurred_at is not newer than stored ended_at; skipped",
+			append(logArgs, "occurredAt", occurredAt)...)
 	}
 }

--- a/worker/session_lifecycle_handler.go
+++ b/worker/session_lifecycle_handler.go
@@ -1,0 +1,108 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/hantabaru1014/baru-reso-headless-controller/domain"
+	"github.com/hantabaru1014/baru-reso-headless-controller/domain/entity"
+	headlessv1 "github.com/hantabaru1014/baru-reso-headless-controller/pbgen/headless/v1"
+	"github.com/hantabaru1014/baru-reso-headless-controller/usecase/port"
+)
+
+// SessionLifecycleHandler keeps the sessions table in sync with the
+// SessionStarted / SessionEnded events emitted by each headless host so
+// that container-internal restarts (auto recover, world restart, ...)
+// are reflected in the DB without going through a controller-side
+// StartSession call.
+type SessionLifecycleHandler struct {
+	sessionRepo port.SessionRepository
+}
+
+func NewSessionLifecycleHandler(sessionRepo port.SessionRepository) *SessionLifecycleHandler {
+	return &SessionLifecycleHandler{sessionRepo: sessionRepo}
+}
+
+var _ HostEventHandler = (*SessionLifecycleHandler)(nil)
+
+func (h *SessionLifecycleHandler) HandleHostEvent(ctx context.Context, hostID string, ev *headlessv1.HostEvent) {
+	occurredAt := ev.GetOccurredAt().AsTime()
+
+	switch payload := ev.GetPayload().(type) {
+	case *headlessv1.HostEvent_SessionStarted:
+		h.handleSessionStarted(ctx, hostID, ev.GetId(), occurredAt, payload.SessionStarted)
+	case *headlessv1.HostEvent_SessionEnded:
+		h.handleSessionEnded(ctx, ev.GetId(), occurredAt, payload.SessionEnded)
+	}
+}
+
+func (h *SessionLifecycleHandler) HandleHostEventStreamReset(_ context.Context, _ string) {}
+
+func (h *SessionLifecycleHandler) handleSessionStarted(ctx context.Context, hostID, eventID string, occurredAt time.Time, payload *headlessv1.SessionStarted) {
+	sessionID := payload.GetSessionId()
+	logArgs := []any{"hostID", hostID, "eventID", eventID, "sessionID", sessionID}
+
+	existing, err := h.sessionRepo.Get(ctx, sessionID)
+
+	switch {
+	case errors.Is(err, domain.ErrNotFound):
+		existing = &entity.Session{
+			ID:     sessionID,
+			HostID: hostID,
+		}
+	case err != nil:
+		slog.Error("session-lifecycle: failed to load session for SessionStarted",
+			append(logArgs, "error", err)...)
+
+		return
+	case existing.StartedAt != nil && !occurredAt.After(*existing.StartedAt):
+		slog.Debug("session-lifecycle: SessionStarted occurred_at is not newer than stored started_at; skipping",
+			append(logArgs, "occurredAt", occurredAt, "storedStartedAt", *existing.StartedAt)...)
+
+		return
+	}
+
+	existing.Name = payload.GetSessionName()
+	existing.Status = entity.SessionStatus_RUNNING
+	existing.StartedAt = &occurredAt
+	existing.EndedAt = nil
+
+	if err := h.sessionRepo.Upsert(ctx, existing); err != nil {
+		slog.Error("session-lifecycle: failed to upsert session from SessionStarted",
+			append(logArgs, "error", err)...)
+	}
+}
+
+func (h *SessionLifecycleHandler) handleSessionEnded(ctx context.Context, eventID string, occurredAt time.Time, payload *headlessv1.SessionEnded) {
+	sessionID := payload.GetSessionId()
+	logArgs := []any{"eventID", eventID, "sessionID", sessionID}
+
+	existing, err := h.sessionRepo.Get(ctx, sessionID)
+
+	switch {
+	case errors.Is(err, domain.ErrNotFound):
+		slog.Warn("session-lifecycle: SessionEnded for unknown session; skipping", logArgs...)
+
+		return
+	case err != nil:
+		slog.Error("session-lifecycle: failed to load session for SessionEnded",
+			append(logArgs, "error", err)...)
+
+		return
+	case existing.EndedAt != nil && !occurredAt.After(*existing.EndedAt):
+		slog.Debug("session-lifecycle: SessionEnded occurred_at is not newer than stored ended_at; skipping",
+			append(logArgs, "occurredAt", occurredAt, "storedEndedAt", *existing.EndedAt)...)
+
+		return
+	}
+
+	existing.Status = entity.SessionStatus_ENDED
+	existing.EndedAt = &occurredAt
+
+	if err := h.sessionRepo.Upsert(ctx, existing); err != nil {
+		slog.Error("session-lifecycle: failed to upsert session from SessionEnded",
+			append(logArgs, "error", err)...)
+	}
+}

--- a/worker/session_lifecycle_handler_test.go
+++ b/worker/session_lifecycle_handler_test.go
@@ -20,8 +20,13 @@ import (
 // It mimics the real adapter's behaviour as closely as practical:
 //   - Upsert rejects sessions whose StartupParameters is nil (mirrors the
 //     sessions.startup_parameters JSONB NOT NULL constraint).
+//   - InsertFromEvent is a no-op when a row already exists (mirrors the
+//     ON CONFLICT DO NOTHING semantics).
 //   - ApplySessionStarted / ApplySessionEnded enforce the same occurred_at
-//     guard their SQL counterparts do.
+//     and host_id guards their SQL counterparts do.
+//
+// The real SQL guards are additionally covered by an integration test in
+// adapter/session_repository_test.go.
 type fakeSessionRepo struct {
 	port.SessionRepository
 
@@ -72,6 +77,29 @@ func (r *fakeSessionRepo) Upsert(_ context.Context, session *entity.Session) err
 	return nil
 }
 
+func (r *fakeSessionRepo) InsertFromEvent(_ context.Context, session *entity.Session) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.upsertErr != nil {
+		return r.upsertErr
+	}
+
+	if session.StartupParameters == nil {
+		return errors.New("startup_parameters must not be nil (would violate NOT NULL)")
+	}
+
+	if _, exists := r.sessions[session.ID]; exists {
+		// ON CONFLICT DO NOTHING
+		return nil
+	}
+
+	clone := *session
+	r.sessions[session.ID] = &clone
+
+	return nil
+}
+
 func (r *fakeSessionRepo) UpdateStatus(_ context.Context, id string, status entity.SessionStatus) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -108,12 +136,16 @@ func (r *fakeSessionRepo) ApplySessionStarted(_ context.Context, id, hostID, nam
 	return true, nil
 }
 
-func (r *fakeSessionRepo) ApplySessionEnded(_ context.Context, id string, occurredAt time.Time) (bool, error) {
+func (r *fakeSessionRepo) ApplySessionEnded(_ context.Context, id, hostID string, occurredAt time.Time) (bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	s, ok := r.sessions[id]
 	if !ok {
+		return false, nil
+	}
+
+	if s.HostID != hostID {
 		return false, nil
 	}
 
@@ -330,18 +362,35 @@ func TestSessionLifecycleHandler_SessionStarted(t *testing.T) {
 		assert.True(t, got.StartedAt.Equal(newStart))
 	})
 
-	t.Run("Get エラー時は state を変更しない", func(t *testing.T) {
+	t.Run("InsertFromEvent エラー時は state を変更しない", func(t *testing.T) {
 		t.Parallel()
 
 		repo := newFakeSessionRepo()
-		repo.getErr = errors.New("db down")
+		repo.upsertErr = errors.New("db down")
 
 		h := NewSessionLifecycleHandler(repo)
 		h.HandleHostEvent(ctx, "host-1",
 			sessionStartedEvent(time.Now(), "session-1", "anything"))
 
 		assert.Nil(t, repo.snapshot("session-1"),
-			"transient errors must not silently insert a partial session")
+			"transient insert errors must not silently leave a partial session")
+	})
+
+	t.Run("occurred_at が未指定なら event 全体を drop する", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newFakeSessionRepo()
+		h := NewSessionLifecycleHandler(repo)
+
+		h.HandleHostEvent(ctx, "host-1", &headlessv1.HostEvent{
+			Id: "01EVENT",
+			Payload: &headlessv1.HostEvent_SessionStarted{
+				SessionStarted: &headlessv1.SessionStarted{SessionId: "session-1", SessionName: "n"},
+			},
+		})
+
+		assert.Nil(t, repo.snapshot("session-1"),
+			"event with missing occurred_at must not create a zero-time row")
 	})
 }
 
@@ -496,6 +545,15 @@ func TestSessionLifecycleHandler_HandleHostEventStreamReset(t *testing.T) {
 			StartedAt:         &startedAt,
 			StartupParameters: &headlessv1.WorldStartupParameters{},
 		})
+		// STARTING session も触られないことを assert (ListByHostAndStatus が
+		// status=RUNNING のみ拾うことの回帰検知)。
+		repo.seed(&entity.Session{
+			ID:                "starting-1",
+			Status:            entity.SessionStatus_STARTING,
+			HostID:            "host-1",
+			StartedAt:         &startedAt,
+			StartupParameters: &headlessv1.WorldStartupParameters{},
+		})
 		repo.seed(&entity.Session{
 			ID:                "other-host-running",
 			Status:            entity.SessionStatus_RUNNING,
@@ -511,6 +569,8 @@ func TestSessionLifecycleHandler_HandleHostEventStreamReset(t *testing.T) {
 			"host-1 RUNNING session must be demoted to UNKNOWN")
 		assert.Equal(t, entity.SessionStatus_ENDED, repo.snapshot("ended-1").Status,
 			"non-RUNNING sessions on the same host must be left alone")
+		assert.Equal(t, entity.SessionStatus_STARTING, repo.snapshot("starting-1").Status,
+			"STARTING sessions must not be demoted (would clobber in-flight StartSession)")
 		assert.Equal(t, entity.SessionStatus_RUNNING, repo.snapshot("other-host-running").Status,
 			"sessions on a different host must be left alone")
 	})

--- a/worker/session_lifecycle_handler_test.go
+++ b/worker/session_lifecycle_handler_test.go
@@ -1,0 +1,291 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hantabaru1014/baru-reso-headless-controller/domain"
+	"github.com/hantabaru1014/baru-reso-headless-controller/domain/entity"
+	headlessv1 "github.com/hantabaru1014/baru-reso-headless-controller/pbgen/headless/v1"
+	"github.com/hantabaru1014/baru-reso-headless-controller/usecase/port"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// fakeSessionRepo is a minimal in-memory stub of port.SessionRepository.
+// Only Get and Upsert are implemented because that is all
+// SessionLifecycleHandler touches; other methods panic so accidental
+// usage is loud.
+type fakeSessionRepo struct {
+	port.SessionRepository
+
+	mu       sync.Mutex
+	sessions map[string]*entity.Session
+
+	upsertErr error
+	getErr    error
+}
+
+func newFakeSessionRepo() *fakeSessionRepo {
+	return &fakeSessionRepo{sessions: make(map[string]*entity.Session)}
+}
+
+func (r *fakeSessionRepo) Get(_ context.Context, id string) (*entity.Session, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.getErr != nil {
+		return nil, r.getErr
+	}
+
+	s, ok := r.sessions[id]
+	if !ok {
+		return nil, domain.ErrNotFound
+	}
+
+	clone := *s
+
+	return &clone, nil
+}
+
+func (r *fakeSessionRepo) Upsert(_ context.Context, session *entity.Session) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.upsertErr != nil {
+		return r.upsertErr
+	}
+
+	clone := *session
+	r.sessions[session.ID] = &clone
+
+	return nil
+}
+
+func (r *fakeSessionRepo) seed(s *entity.Session) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	clone := *s
+	r.sessions[s.ID] = &clone
+}
+
+func (r *fakeSessionRepo) snapshot(id string) *entity.Session {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	s, ok := r.sessions[id]
+	if !ok {
+		return nil
+	}
+
+	clone := *s
+
+	return &clone
+}
+
+func sessionStartedEvent(t time.Time, sessionID, sessionName string) *headlessv1.HostEvent {
+	return &headlessv1.HostEvent{
+		Id:         "01EVENT",
+		OccurredAt: timestamppb.New(t),
+		Payload: &headlessv1.HostEvent_SessionStarted{
+			SessionStarted: &headlessv1.SessionStarted{
+				SessionId:   sessionID,
+				SessionName: sessionName,
+			},
+		},
+	}
+}
+
+func sessionEndedEvent(t time.Time, sessionID string) *headlessv1.HostEvent {
+	return &headlessv1.HostEvent{
+		Id:         "01EVENT",
+		OccurredAt: timestamppb.New(t),
+		Payload: &headlessv1.HostEvent_SessionEnded{
+			SessionEnded: &headlessv1.SessionEnded{
+				SessionId: sessionID,
+			},
+		},
+	}
+}
+
+func TestSessionLifecycleHandler_SessionStarted(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("既存セッションを最新の occurred_at で更新する", func(t *testing.T) {
+		t.Parallel()
+
+		oldStart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+		endedAt := time.Date(2025, 1, 1, 1, 0, 0, 0, time.UTC)
+		newStart := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+
+		repo := newFakeSessionRepo()
+		repo.seed(&entity.Session{
+			ID:        "session-1",
+			Name:      "old-name",
+			Status:    entity.SessionStatus_ENDED,
+			HostID:    "host-1",
+			StartedAt: &oldStart,
+			EndedAt:   &endedAt,
+		})
+
+		h := NewSessionLifecycleHandler(repo)
+		h.HandleHostEvent(ctx, "host-1", sessionStartedEvent(newStart, "session-1", "new-name"))
+
+		got := repo.snapshot("session-1")
+		require.NotNil(t, got)
+		assert.Equal(t, "new-name", got.Name)
+		assert.Equal(t, entity.SessionStatus_RUNNING, got.Status)
+		require.NotNil(t, got.StartedAt)
+		assert.True(t, got.StartedAt.Equal(newStart))
+		assert.Nil(t, got.EndedAt)
+	})
+
+	t.Run("存在しないセッションは新規作成する", func(t *testing.T) {
+		t.Parallel()
+
+		occurredAt := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+
+		repo := newFakeSessionRepo()
+		h := NewSessionLifecycleHandler(repo)
+		h.HandleHostEvent(ctx, "host-7", sessionStartedEvent(occurredAt, "fresh-session", "fresh-name"))
+
+		got := repo.snapshot("fresh-session")
+		require.NotNil(t, got)
+		assert.Equal(t, "fresh-name", got.Name)
+		assert.Equal(t, "host-7", got.HostID)
+		assert.Equal(t, entity.SessionStatus_RUNNING, got.Status)
+		require.NotNil(t, got.StartedAt)
+		assert.True(t, got.StartedAt.Equal(occurredAt))
+		assert.Nil(t, got.EndedAt)
+	})
+
+	t.Run("古い occurred_at の SessionStarted は無視する", func(t *testing.T) {
+		t.Parallel()
+
+		current := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+		older := time.Date(2025, 5, 1, 0, 0, 0, 0, time.UTC)
+
+		repo := newFakeSessionRepo()
+		repo.seed(&entity.Session{
+			ID:        "session-1",
+			Name:      "current-name",
+			Status:    entity.SessionStatus_RUNNING,
+			HostID:    "host-1",
+			StartedAt: &current,
+		})
+
+		h := NewSessionLifecycleHandler(repo)
+		h.HandleHostEvent(ctx, "host-1", sessionStartedEvent(older, "session-1", "stale-name"))
+
+		got := repo.snapshot("session-1")
+		require.NotNil(t, got)
+		assert.Equal(t, "current-name", got.Name)
+		require.NotNil(t, got.StartedAt)
+		assert.True(t, got.StartedAt.Equal(current), "started_at must not be rewound by an older event")
+	})
+
+	t.Run("repository エラー時は state を変更しない", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newFakeSessionRepo()
+		repo.getErr = errors.New("db down")
+
+		h := NewSessionLifecycleHandler(repo)
+		h.HandleHostEvent(ctx, "host-1",
+			sessionStartedEvent(time.Now(), "session-1", "anything"))
+
+		assert.Nil(t, repo.snapshot("session-1"),
+			"transient errors must not silently insert a partial session")
+	})
+}
+
+func TestSessionLifecycleHandler_SessionEnded(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("既存セッションの ended_at と status を更新する", func(t *testing.T) {
+		t.Parallel()
+
+		startedAt := time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC)
+		endedAt := time.Date(2025, 4, 1, 2, 0, 0, 0, time.UTC)
+
+		repo := newFakeSessionRepo()
+		repo.seed(&entity.Session{
+			ID:        "session-1",
+			Name:      "name",
+			Status:    entity.SessionStatus_RUNNING,
+			HostID:    "host-1",
+			StartedAt: &startedAt,
+		})
+
+		h := NewSessionLifecycleHandler(repo)
+		h.HandleHostEvent(ctx, "host-1", sessionEndedEvent(endedAt, "session-1"))
+
+		got := repo.snapshot("session-1")
+		require.NotNil(t, got)
+		assert.Equal(t, entity.SessionStatus_ENDED, got.Status)
+		require.NotNil(t, got.EndedAt)
+		assert.True(t, got.EndedAt.Equal(endedAt))
+	})
+
+	t.Run("未知の session_id はスキップする", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newFakeSessionRepo()
+		h := NewSessionLifecycleHandler(repo)
+		h.HandleHostEvent(ctx, "host-1",
+			sessionEndedEvent(time.Now(), "ghost-session"))
+
+		assert.Nil(t, repo.snapshot("ghost-session"),
+			"unknown session ends must not create a ghost row")
+	})
+
+	t.Run("巻き戻し ended_at は無視する", func(t *testing.T) {
+		t.Parallel()
+
+		endedAt := time.Date(2025, 5, 1, 0, 0, 0, 0, time.UTC)
+		older := time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC)
+
+		repo := newFakeSessionRepo()
+		repo.seed(&entity.Session{
+			ID:      "session-1",
+			Status:  entity.SessionStatus_ENDED,
+			HostID:  "host-1",
+			EndedAt: &endedAt,
+		})
+
+		h := NewSessionLifecycleHandler(repo)
+		h.HandleHostEvent(ctx, "host-1", sessionEndedEvent(older, "session-1"))
+
+		got := repo.snapshot("session-1")
+		require.NotNil(t, got)
+		require.NotNil(t, got.EndedAt)
+		assert.True(t, got.EndedAt.Equal(endedAt),
+			"ended_at must not be rewound by an older event")
+	})
+}
+
+func TestSessionLifecycleHandler_IgnoresUnrelatedPayloads(t *testing.T) {
+	t.Parallel()
+
+	repo := newFakeSessionRepo()
+	h := NewSessionLifecycleHandler(repo)
+
+	h.HandleHostEvent(t.Context(), "host-1", &headlessv1.HostEvent{
+		Id:         "01EVENT",
+		OccurredAt: timestamppb.New(time.Now()),
+		Payload: &headlessv1.HostEvent_WorldSaved{
+			WorldSaved: &headlessv1.WorldSaved{SessionId: "session-1"},
+		},
+	})
+
+	assert.Empty(t, repo.sessions, "non-lifecycle payloads must not touch the repo")
+}

--- a/worker/session_lifecycle_handler_test.go
+++ b/worker/session_lifecycle_handler_test.go
@@ -16,10 +16,12 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// fakeSessionRepo is a minimal in-memory stub of port.SessionRepository.
-// Only Get and Upsert are implemented because that is all
-// SessionLifecycleHandler touches; other methods panic so accidental
-// usage is loud.
+// fakeSessionRepo is an in-memory port.SessionRepository for handler tests.
+// It mimics the real adapter's behaviour as closely as practical:
+//   - Upsert rejects sessions whose StartupParameters is nil (mirrors the
+//     sessions.startup_parameters JSONB NOT NULL constraint).
+//   - ApplySessionStarted / ApplySessionEnded enforce the same occurred_at
+//     guard their SQL counterparts do.
 type fakeSessionRepo struct {
 	port.SessionRepository
 
@@ -60,10 +62,85 @@ func (r *fakeSessionRepo) Upsert(_ context.Context, session *entity.Session) err
 		return r.upsertErr
 	}
 
+	if session.StartupParameters == nil {
+		return errors.New("startup_parameters must not be nil (would violate NOT NULL)")
+	}
+
 	clone := *session
 	r.sessions[session.ID] = &clone
 
 	return nil
+}
+
+func (r *fakeSessionRepo) UpdateStatus(_ context.Context, id string, status entity.SessionStatus) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	s, ok := r.sessions[id]
+	if !ok {
+		return domain.ErrNotFound
+	}
+
+	s.Status = status
+
+	return nil
+}
+
+func (r *fakeSessionRepo) ApplySessionStarted(_ context.Context, id, hostID, name string, occurredAt time.Time) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	s, ok := r.sessions[id]
+	if !ok {
+		return false, nil
+	}
+
+	if s.StartedAt != nil && !occurredAt.After(*s.StartedAt) {
+		return false, nil
+	}
+
+	s.Name = name
+	s.Status = entity.SessionStatus_RUNNING
+	s.StartedAt = &occurredAt
+	s.EndedAt = nil
+	s.HostID = hostID
+
+	return true, nil
+}
+
+func (r *fakeSessionRepo) ApplySessionEnded(_ context.Context, id string, occurredAt time.Time) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	s, ok := r.sessions[id]
+	if !ok {
+		return false, nil
+	}
+
+	if s.EndedAt != nil && !occurredAt.After(*s.EndedAt) {
+		return false, nil
+	}
+
+	s.Status = entity.SessionStatus_ENDED
+	s.EndedAt = &occurredAt
+
+	return true, nil
+}
+
+func (r *fakeSessionRepo) ListByHostAndStatus(_ context.Context, hostID string, status entity.SessionStatus) (entity.SessionList, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	out := entity.SessionList{}
+
+	for _, s := range r.sessions {
+		if s.HostID == hostID && s.Status == status {
+			clone := *s
+			out = append(out, &clone)
+		}
+	}
+
+	return out, nil
 }
 
 func (r *fakeSessionRepo) seed(s *entity.Session) {
@@ -113,12 +190,14 @@ func sessionEndedEvent(t time.Time, sessionID string) *headlessv1.HostEvent {
 	}
 }
 
+func ptr[T any](v T) *T { return &v }
+
 func TestSessionLifecycleHandler_SessionStarted(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
 
-	t.Run("既存セッションを最新の occurred_at で更新する", func(t *testing.T) {
+	t.Run("既存セッションを最新の occurred_at で更新する (他フィールドは保持)", func(t *testing.T) {
 		t.Parallel()
 
 		oldStart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -127,12 +206,16 @@ func TestSessionLifecycleHandler_SessionStarted(t *testing.T) {
 
 		repo := newFakeSessionRepo()
 		repo.seed(&entity.Session{
-			ID:        "session-1",
-			Name:      "old-name",
-			Status:    entity.SessionStatus_ENDED,
-			HostID:    "host-1",
-			StartedAt: &oldStart,
-			EndedAt:   &endedAt,
+			ID:                "session-1",
+			Name:              "old-name",
+			Status:            entity.SessionStatus_ENDED,
+			HostID:            "host-1",
+			StartedAt:         &oldStart,
+			EndedAt:           &endedAt,
+			OwnerID:           ptr("owner-1"),
+			Memo:              "important note",
+			AutoUpgrade:       true,
+			StartupParameters: &headlessv1.WorldStartupParameters{},
 		})
 
 		h := NewSessionLifecycleHandler(repo)
@@ -145,9 +228,13 @@ func TestSessionLifecycleHandler_SessionStarted(t *testing.T) {
 		require.NotNil(t, got.StartedAt)
 		assert.True(t, got.StartedAt.Equal(newStart))
 		assert.Nil(t, got.EndedAt)
+		// 部分更新により他フィールドは保持される
+		assert.Equal(t, ptr("owner-1"), got.OwnerID)
+		assert.Equal(t, "important note", got.Memo)
+		assert.True(t, got.AutoUpgrade)
 	})
 
-	t.Run("存在しないセッションは新規作成する", func(t *testing.T) {
+	t.Run("存在しないセッションは新規作成する (StartupParameters は non-nil)", func(t *testing.T) {
 		t.Parallel()
 
 		occurredAt := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
@@ -164,9 +251,11 @@ func TestSessionLifecycleHandler_SessionStarted(t *testing.T) {
 		require.NotNil(t, got.StartedAt)
 		assert.True(t, got.StartedAt.Equal(occurredAt))
 		assert.Nil(t, got.EndedAt)
+		require.NotNil(t, got.StartupParameters,
+			"new session must have non-nil StartupParameters to satisfy DB NOT NULL")
 	})
 
-	t.Run("古い occurred_at の SessionStarted は無視する", func(t *testing.T) {
+	t.Run("古い occurred_at の SessionStarted は SQL ガードで skip される", func(t *testing.T) {
 		t.Parallel()
 
 		current := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
@@ -174,11 +263,12 @@ func TestSessionLifecycleHandler_SessionStarted(t *testing.T) {
 
 		repo := newFakeSessionRepo()
 		repo.seed(&entity.Session{
-			ID:        "session-1",
-			Name:      "current-name",
-			Status:    entity.SessionStatus_RUNNING,
-			HostID:    "host-1",
-			StartedAt: &current,
+			ID:                "session-1",
+			Name:              "current-name",
+			Status:            entity.SessionStatus_RUNNING,
+			HostID:            "host-1",
+			StartedAt:         &current,
+			StartupParameters: &headlessv1.WorldStartupParameters{},
 		})
 
 		h := NewSessionLifecycleHandler(repo)
@@ -191,7 +281,56 @@ func TestSessionLifecycleHandler_SessionStarted(t *testing.T) {
 		assert.True(t, got.StartedAt.Equal(current), "started_at must not be rewound by an older event")
 	})
 
-	t.Run("repository エラー時は state を変更しない", func(t *testing.T) {
+	t.Run("occurred_at == 既存 started_at の場合も skip される", func(t *testing.T) {
+		t.Parallel()
+
+		ts := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+
+		repo := newFakeSessionRepo()
+		repo.seed(&entity.Session{
+			ID:                "session-1",
+			Name:              "current-name",
+			Status:            entity.SessionStatus_RUNNING,
+			HostID:            "host-1",
+			StartedAt:         &ts,
+			StartupParameters: &headlessv1.WorldStartupParameters{},
+		})
+
+		h := NewSessionLifecycleHandler(repo)
+		h.HandleHostEvent(ctx, "host-1", sessionStartedEvent(ts, "session-1", "same-time"))
+
+		got := repo.snapshot("session-1")
+		require.NotNil(t, got)
+		assert.Equal(t, "current-name", got.Name, "equal occurred_at must not overwrite the name")
+	})
+
+	t.Run("別 host から来た SessionStarted は host_id を更新する", func(t *testing.T) {
+		t.Parallel()
+
+		oldStart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+		newStart := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+
+		repo := newFakeSessionRepo()
+		repo.seed(&entity.Session{
+			ID:                "session-1",
+			Name:              "name",
+			Status:            entity.SessionStatus_RUNNING,
+			HostID:            "host-A",
+			StartedAt:         &oldStart,
+			StartupParameters: &headlessv1.WorldStartupParameters{},
+		})
+
+		h := NewSessionLifecycleHandler(repo)
+		h.HandleHostEvent(ctx, "host-B", sessionStartedEvent(newStart, "session-1", "name"))
+
+		got := repo.snapshot("session-1")
+		require.NotNil(t, got)
+		assert.Equal(t, "host-B", got.HostID, "SessionStarted from a new host must update host_id")
+		require.NotNil(t, got.StartedAt)
+		assert.True(t, got.StartedAt.Equal(newStart))
+	})
+
+	t.Run("Get エラー時は state を変更しない", func(t *testing.T) {
 		t.Parallel()
 
 		repo := newFakeSessionRepo()
@@ -211,7 +350,7 @@ func TestSessionLifecycleHandler_SessionEnded(t *testing.T) {
 
 	ctx := t.Context()
 
-	t.Run("既存セッションの ended_at と status を更新する", func(t *testing.T) {
+	t.Run("既存セッションの ended_at と status を更新する (他フィールドは保持)", func(t *testing.T) {
 		t.Parallel()
 
 		startedAt := time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC)
@@ -219,11 +358,15 @@ func TestSessionLifecycleHandler_SessionEnded(t *testing.T) {
 
 		repo := newFakeSessionRepo()
 		repo.seed(&entity.Session{
-			ID:        "session-1",
-			Name:      "name",
-			Status:    entity.SessionStatus_RUNNING,
-			HostID:    "host-1",
-			StartedAt: &startedAt,
+			ID:                "session-1",
+			Name:              "name",
+			Status:            entity.SessionStatus_RUNNING,
+			HostID:            "host-1",
+			StartedAt:         &startedAt,
+			OwnerID:           ptr("owner-1"),
+			Memo:              "important note",
+			AutoUpgrade:       true,
+			StartupParameters: &headlessv1.WorldStartupParameters{},
 		})
 
 		h := NewSessionLifecycleHandler(repo)
@@ -234,6 +377,10 @@ func TestSessionLifecycleHandler_SessionEnded(t *testing.T) {
 		assert.Equal(t, entity.SessionStatus_ENDED, got.Status)
 		require.NotNil(t, got.EndedAt)
 		assert.True(t, got.EndedAt.Equal(endedAt))
+		assert.Equal(t, "name", got.Name)
+		assert.Equal(t, ptr("owner-1"), got.OwnerID)
+		assert.Equal(t, "important note", got.Memo)
+		assert.True(t, got.AutoUpgrade)
 	})
 
 	t.Run("未知の session_id はスキップする", func(t *testing.T) {
@@ -256,10 +403,11 @@ func TestSessionLifecycleHandler_SessionEnded(t *testing.T) {
 
 		repo := newFakeSessionRepo()
 		repo.seed(&entity.Session{
-			ID:      "session-1",
-			Status:  entity.SessionStatus_ENDED,
-			HostID:  "host-1",
-			EndedAt: &endedAt,
+			ID:                "session-1",
+			Status:            entity.SessionStatus_ENDED,
+			HostID:            "host-1",
+			EndedAt:           &endedAt,
+			StartupParameters: &headlessv1.WorldStartupParameters{},
 		})
 
 		h := NewSessionLifecycleHandler(repo)
@@ -270,6 +418,109 @@ func TestSessionLifecycleHandler_SessionEnded(t *testing.T) {
 		require.NotNil(t, got.EndedAt)
 		assert.True(t, got.EndedAt.Equal(endedAt),
 			"ended_at must not be rewound by an older event")
+	})
+
+	t.Run("別 host からの SessionEnded はスキップする", func(t *testing.T) {
+		t.Parallel()
+
+		startedAt := time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC)
+
+		repo := newFakeSessionRepo()
+		repo.seed(&entity.Session{
+			ID:                "session-1",
+			Name:              "name",
+			Status:            entity.SessionStatus_RUNNING,
+			HostID:            "host-current",
+			StartedAt:         &startedAt,
+			StartupParameters: &headlessv1.WorldStartupParameters{},
+		})
+
+		h := NewSessionLifecycleHandler(repo)
+		h.HandleHostEvent(ctx, "host-stale",
+			sessionEndedEvent(time.Date(2025, 4, 1, 2, 0, 0, 0, time.UTC), "session-1"))
+
+		got := repo.snapshot("session-1")
+		require.NotNil(t, got)
+		assert.Equal(t, entity.SessionStatus_RUNNING, got.Status,
+			"SessionEnded from a non-owning host must not flip status to ENDED")
+		assert.Nil(t, got.EndedAt)
+	})
+
+	t.Run("started_at より前の occurred_at はスキップする", func(t *testing.T) {
+		t.Parallel()
+
+		startedAt := time.Date(2025, 5, 1, 0, 0, 0, 0, time.UTC)
+		bogusEnd := time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC)
+
+		repo := newFakeSessionRepo()
+		repo.seed(&entity.Session{
+			ID:                "session-1",
+			Status:            entity.SessionStatus_RUNNING,
+			HostID:            "host-1",
+			StartedAt:         &startedAt,
+			StartupParameters: &headlessv1.WorldStartupParameters{},
+		})
+
+		h := NewSessionLifecycleHandler(repo)
+		h.HandleHostEvent(ctx, "host-1", sessionEndedEvent(bogusEnd, "session-1"))
+
+		got := repo.snapshot("session-1")
+		require.NotNil(t, got)
+		assert.Equal(t, entity.SessionStatus_RUNNING, got.Status)
+		assert.Nil(t, got.EndedAt)
+	})
+}
+
+func TestSessionLifecycleHandler_HandleHostEventStreamReset(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	t.Run("hostID 配下の RUNNING セッションのみ UNKNOWN に倒す", func(t *testing.T) {
+		t.Parallel()
+
+		startedAt := time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC)
+
+		repo := newFakeSessionRepo()
+		repo.seed(&entity.Session{
+			ID:                "running-1",
+			Status:            entity.SessionStatus_RUNNING,
+			HostID:            "host-1",
+			StartedAt:         &startedAt,
+			StartupParameters: &headlessv1.WorldStartupParameters{},
+		})
+		repo.seed(&entity.Session{
+			ID:                "ended-1",
+			Status:            entity.SessionStatus_ENDED,
+			HostID:            "host-1",
+			StartedAt:         &startedAt,
+			StartupParameters: &headlessv1.WorldStartupParameters{},
+		})
+		repo.seed(&entity.Session{
+			ID:                "other-host-running",
+			Status:            entity.SessionStatus_RUNNING,
+			HostID:            "host-2",
+			StartedAt:         &startedAt,
+			StartupParameters: &headlessv1.WorldStartupParameters{},
+		})
+
+		h := NewSessionLifecycleHandler(repo)
+		h.HandleHostEventStreamReset(ctx, "host-1")
+
+		assert.Equal(t, entity.SessionStatus_UNKNOWN, repo.snapshot("running-1").Status,
+			"host-1 RUNNING session must be demoted to UNKNOWN")
+		assert.Equal(t, entity.SessionStatus_ENDED, repo.snapshot("ended-1").Status,
+			"non-RUNNING sessions on the same host must be left alone")
+		assert.Equal(t, entity.SessionStatus_RUNNING, repo.snapshot("other-host-running").Status,
+			"sessions on a different host must be left alone")
+	})
+
+	t.Run("対象が無い場合は no-op", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newFakeSessionRepo()
+		h := NewSessionLifecycleHandler(repo)
+		h.HandleHostEventStreamReset(ctx, "host-empty")
 	})
 }
 


### PR DESCRIPTION
## Summary
- container の world 再起動 (auto recover / 手動 restart) で発火する
  SessionStarted / SessionEnded が DB に反映されず、started_at が
  古いまま残る不具合を、HostEventWatcher 経由の handler で解消する。
- 部分更新 SQL (`ApplySessionStarted` / `ApplySessionEnded`) と
  `InsertSessionFromEvent` (`ON CONFLICT DO NOTHING`) を分離し、
  並行する StartSession / UpdateSessionParameters と memo / owner_id /
  startup_parameters を取り合わない設計。
- at-least-once 配信の重複・巻き戻し・別 host への session 移動を
  occurred_at + host_id の WHERE 条件で SQL レベルで防御する。
- stream reset (OutOfRange) 時は当該 host の RUNNING を UNKNOWN に
  倒し、次の event で正規化されるのを待つ。

## Test plan
- [ ] \`go test ./...\` (integration test 含む) が通る
- [ ] 実機で world 再起動 (auto recover) 時に sessions の
      started_at / ended_at / status が更新される
- [ ] host UI 直起動で新しい session 行が作成される
- [ ] custom_session_id で別 host に移動した session について、
      古い host 由来の SessionEnded で誤って ENDED にならない