### PR TITLE
fix(resonite-link): token TTLを5h化 / 接続リーク対策

### DIFF
--- a/adapter/resonitelink/ws_bridge.go
+++ b/adapter/resonitelink/ws_bridge.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -27,6 +28,17 @@ import (
 // WSPath は HTTP サーバが Bridge をマウントするパス.
 // 発行する ws_path もこのパスを使う (mount 先と発行先のずれを防ぐため共有).
 const WSPath = "/resonite-link/ws"
+
+// peer が無言で死んだ場合に gRPC stream を握り続けて
+// 接続数カウントが減らなくなるのを防ぐための liveness 設定.
+const (
+	// pongWait は次の pong / メッセージを受信するまで待てる最大時間.
+	pongWait = 60 * time.Second
+	// pingPeriod は ping を送る周期. pongWait より十分短く.
+	pingPeriod = (pongWait * 9) / 10 //nolint:mnd // 9/10: pong 到着前に次の ping を送るためのマージン
+	// writeWait は 1 フレームの書き込みに許容するタイムアウト.
+	writeWait = 10 * time.Second
+)
 
 // BuildWSPath は token を埋めた path + query を返す.
 // host は呼び出し側 (フロントエンド) で補完する.
@@ -82,7 +94,11 @@ func (b *Bridge) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	streamCtx, cancel := context.WithCancel(r.Context())
+	// token の有効期限を streamCtx の deadline に載せる. これで token 期限到達時に
+	// gRPC stream と pumpFrames 配下の goroutine が ctx 経由で自然に終わり、
+	// container 側の clients count もそのまま減る. ParseResoniteLinkToken は
+	// jwt.WithExpirationRequired を強制しているので ExpiresAt は必ず非 nil.
+	streamCtx, cancel := context.WithDeadline(r.Context(), claims.ExpiresAt.Time)
 	defer cancel()
 
 	client, err := b.hhrepo.GetRpcClient(streamCtx, sess.HostID)
@@ -128,7 +144,7 @@ func (b *Bridge) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	defer func() { _ = conn.Close() }()
 
-	if err := pumpFrames(streamCtx, conn, stream); err != nil {
+	if err := pumpFrames(streamCtx, cancel, conn, stream); err != nil {
 		slog.Debug("resonite link bridge ended", "session_id", claims.SessionID, "error", err)
 	}
 }
@@ -152,15 +168,70 @@ func waitReady(stream headlessv1.HeadlessControlService_ResoniteLinkStreamClient
 	return nil
 }
 
+// cancelStream はこの bridge に対応する gRPC streamCtx を cancel するためのもの.
+// pumpFrames 内で片方の経路が終了したとき、もう片方が ReadMessage / stream.Recv で
+// 永久ブロックしないよう、conn.Close と合わせて gRPC stream も起こす.
 func pumpFrames(
 	ctx context.Context,
+	cancelStream context.CancelFunc,
 	conn *websocket.Conn,
 	stream headlessv1.HeadlessControlService_ResoniteLinkStreamClient,
 ) error {
-	eg, _ := errgroup.WithContext(ctx)
+	// peer が無言で死んだら ReadMessage を確実に起こすため
+	// pongWait の deadline を設定し、pong / メッセージ受信のたびに延長する.
+	_ = conn.SetReadDeadline(time.Now().Add(pongWait))
+	conn.SetPongHandler(func(string) error {
+		_ = conn.SetReadDeadline(time.Now().Add(pongWait))
+		return nil
+	})
+
+	// conn.WriteMessage / WriteControl は並行呼び出し不可なので writer をシリアライズする.
+	var writeMu sync.Mutex
+
+	writeFrame := func(messageType int, data []byte) error {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+
+		_ = conn.SetWriteDeadline(time.Now().Add(writeWait))
+
+		return conn.WriteMessage(messageType, data)
+	}
+
+	// どこかの経路が終わったら conn を閉じて gRPC stream を cancel し、
+	// 反対側の Read / Recv を起こす. conn.Close も CancelFunc も idempotent なので
+	// 複数 goroutine の defer から呼ばれて問題ない. cancelStream は ctx も cancel するため
+	// ping ticker は ctx.Done() で抜ける.
+	closeAll := func() {
+		_ = conn.Close()
+
+		cancelStream()
+	}
+
+	var eg errgroup.Group
+
+	// ping ticker: peer 生存確認.
+	eg.Go(func() error {
+		defer closeAll()
+
+		ticker := time.NewTicker(pingPeriod)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-ticker.C:
+				if err := writeFrame(websocket.PingMessage, nil); err != nil {
+					return err
+				}
+			}
+		}
+	})
 
 	// WebSocket -> gRPC
 	eg.Go(func() error {
+		defer closeAll()
+
 		for {
 			messageType, data, err := conn.ReadMessage()
 			if err != nil {
@@ -171,6 +242,9 @@ func pumpFrames(
 
 				return err
 			}
+
+			// メッセージが届いている間は peer 生存なので deadline 延長.
+			_ = conn.SetReadDeadline(time.Now().Add(pongWait))
 
 			var req *headlessv1.ResoniteLinkStreamRequest
 
@@ -191,11 +265,13 @@ func pumpFrames(
 
 	// gRPC -> WebSocket
 	eg.Go(func() error {
+		defer closeAll()
+
 		for {
 			msg, err := stream.Recv()
 			if err != nil {
 				if errors.Is(err, io.EOF) {
-					_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+					_ = writeFrame(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 					return nil
 				}
 
@@ -204,11 +280,11 @@ func pumpFrames(
 
 			switch p := msg.GetPayload().(type) {
 			case *headlessv1.ResoniteLinkStreamResponse_TextFrame:
-				if err := conn.WriteMessage(websocket.TextMessage, []byte(p.TextFrame)); err != nil {
+				if err := writeFrame(websocket.TextMessage, []byte(p.TextFrame)); err != nil {
 					return err
 				}
 			case *headlessv1.ResoniteLinkStreamResponse_BinaryFrame:
-				if err := conn.WriteMessage(websocket.BinaryMessage, p.BinaryFrame); err != nil {
+				if err := writeFrame(websocket.BinaryMessage, p.BinaryFrame); err != nil {
 					return err
 				}
 			}

--- a/adapter/resonitelink/ws_bridge_test.go
+++ b/adapter/resonitelink/ws_bridge_test.go
@@ -139,10 +139,10 @@ func wsURL(server *httptest.Server, query string) string {
 	return "ws" + strings.TrimPrefix(server.URL, "http") + "/?" + query
 }
 
-func issueToken(t *testing.T, sessionID string) string {
+func issueToken(t *testing.T, ttl time.Duration) string {
 	t.Helper()
 
-	token, _, err := auth.GenerateResoniteLinkToken("U-test", sessionID, time.Minute)
+	token, _, err := auth.GenerateResoniteLinkToken("U-test", testSessionID, ttl)
 	require.NoError(t, err)
 
 	return token
@@ -161,7 +161,7 @@ func TestBridge_HappyPath_TextAndBinary(t *testing.T) {
 	tb := startTestBridge(t)
 	readyOnce(tb.stream)
 
-	token := issueToken(t, testSessionID)
+	token := issueToken(t, time.Minute)
 
 	conn, resp, err := websocket.DefaultDialer.Dial(wsURL(tb.server, "token="+url.QueryEscape(token)), nil)
 	require.NoError(t, err)
@@ -252,7 +252,7 @@ func TestBridge_SessionNotFound_Returns404(t *testing.T) {
 	tb := startTestBridge(t)
 	delete(tb.sessRepo.sessions, testSessionID)
 
-	token := issueToken(t, testSessionID)
+	token := issueToken(t, time.Minute)
 	_, resp, err := websocket.DefaultDialer.Dial(wsURL(tb.server, "token="+url.QueryEscape(token)), nil)
 	require.Error(t, err)
 	require.NotNil(t, resp)
@@ -278,10 +278,83 @@ func TestBridge_WrongAudienceToken_Returns401(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
 
+// WebSocket クライアントが切断したら gRPC streamCtx も cancel され、
+// container 側の Recv() が起きて clients count が減ることを保証する.
+// (これが効かないと token 期限切れ後のゾンビ接続が container にも残る.)
+func TestBridge_ClientClose_CancelsGrpcStream(t *testing.T) {
+	tb := startTestBridge(t)
+	readyOnce(tb.stream)
+
+	token := issueToken(t, time.Minute)
+
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL(tb.server, "token="+url.QueryEscape(token)), nil)
+	require.NoError(t, err)
+
+	defer func() { _ = resp.Body.Close() }()
+
+	// Init が gRPC stream に届くまで待って stream の ctx が確立されたことを担保.
+	select {
+	case <-tb.stream.sentCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Init was not forwarded to gRPC stream")
+	}
+
+	streamCtx := tb.stream.ctx
+
+	// 正常クローズ送信. bridge は CloseSend してこちらの送信ループを抜ける.
+	require.NoError(t, conn.WriteMessage(websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")))
+	_ = conn.Close()
+
+	// クライアント切断が伝播して gRPC streamCtx が cancel されることを確認.
+	// (これが起きないと container 側の Recv が永久に起きず、bridge の clients count が減らない)
+	select {
+	case <-streamCtx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("gRPC stream ctx was not cancelled after WS close")
+	}
+}
+
+// token 期限切れ到達で WS と gRPC stream の両方が閉じられることを保証する.
+// (これがないと長時間 WS を維持された場合に期限切れ token のまま接続が居座り、
+// container 側の clients count も減らない.)
+func TestBridge_TokenExpiry_ClosesConnection(t *testing.T) {
+	tb := startTestBridge(t)
+	readyOnce(tb.stream)
+
+	shortToken := issueToken(t, 2*time.Second)
+
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL(tb.server, "token="+url.QueryEscape(shortToken)), nil)
+	require.NoError(t, err)
+
+	defer func() { _ = resp.Body.Close() }()
+	defer func() { _ = conn.Close() }()
+
+	// Init が流れたことを確認して streamCtx を握っておく.
+	select {
+	case <-tb.stream.sentCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Init was not forwarded to gRPC stream")
+	}
+
+	streamCtx := tb.stream.ctx
+
+	// token 有効期限到達で WS / gRPC stream が閉じられる. WS read が起きる.
+	_ = conn.SetReadDeadline(time.Now().Add(4 * time.Second))
+	_, _, err = conn.ReadMessage()
+	require.Error(t, err, "WS read should fail after token expiry")
+
+	select {
+	case <-streamCtx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("gRPC stream ctx was not cancelled after token expiry")
+	}
+}
+
 func TestBridge_ReadyTimeout_Returns502(t *testing.T) {
 	tb := startTestBridge(t)
 	// Ready を一切送らない -> readyTimeout 経過で 502
-	token := issueToken(t, testSessionID)
+	token := issueToken(t, time.Minute)
 
 	_, resp, err := websocket.DefaultDialer.Dial(wsURL(tb.server, "token="+url.QueryEscape(token)), nil)
 	require.Error(t, err)

--- a/config/config.go
+++ b/config/config.go
@@ -116,7 +116,7 @@ func LoadEnvConfig() (*EnvConfig, error) {
 	cfg.Server.SessionPortMin = portMin
 	cfg.Server.SessionPortMax = portMax
 
-	cfg.ResoniteLink.TokenTTL = getEnvDuration("RESONITE_LINK_TOKEN_TTL", 5*time.Minute)   //nolint:mnd // default
+	cfg.ResoniteLink.TokenTTL = getEnvDuration("RESONITE_LINK_TOKEN_TTL", 5*time.Hour)    //nolint:mnd // default
 	cfg.ResoniteLink.ReadyTimeout = getEnvDuration("RESONITE_LINK_READY_TIMEOUT", 5*time.Second) //nolint:mnd // default
 	cfg.ResoniteLink.AllowedOrigins = parseCSV(os.Getenv("RESONITE_LINK_ALLOWED_ORIGINS"))
 


### PR DESCRIPTION
## Summary
- token のデフォルト TTL を 5min → 5h に
- WS bridge に ping/pong + read deadline を入れて、peer が無言で消えたときに gRPC stream が握られ続けて container 側の接続数カウントが減らない問題を解消
- token 有効期限を streamCtx の deadline に載せて、期限到達で WS / gRPC stream が自然に閉じるように

## Test plan
- [ ] `go test ./adapter/resonitelink/...` (追加: WS close で gRPC ctx cancel, token 期限切れで WS/gRPC 終了)
- [ ] 実環境で長時間 (>5min) 接続して container の `resonite_link_clients_count` が増減することを確認