### PR TITLE
feat(front): サイドバー下端にバージョン情報を表示

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Build frontend
         run: pnpm run build
+        env:
+          VITE_APP_VERSION: ${{ github.event.release.tag_name }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0

--- a/front/src/components/SidebarVersionFooter.stories.tsx
+++ b/front/src/components/SidebarVersionFooter.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Clock, Earth, Home, Server, Users } from "lucide-react";
+import { Link, MemoryRouter } from "react-router";
+
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@/components/ui";
+import { SidebarVersionFooter } from "./SidebarVersionFooter";
+
+const navigation = [
+  { title: "Dashboard", href: "/", icon: Home },
+  { title: "Headless Accounts", href: "/headlessAccounts", icon: Users },
+  { title: "Hosts", href: "/hosts", icon: Server },
+  { title: "Sessions", href: "/sessions", icon: Earth, active: true },
+  { title: "Scheduled Ops", href: "/sessions/scheduled", icon: Clock },
+];
+
+const meta = {
+  title: "components/SidebarVersionFooter",
+  component: SidebarVersionFooter,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <SidebarProvider>
+          <Sidebar variant="inset" collapsible="icon">
+            <SidebarContent>
+              <SidebarGroup>
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    {navigation.map((item) => (
+                      <SidebarMenuItem key={item.href}>
+                        <SidebarMenuButton asChild isActive={item.active}>
+                          <Link to={item.href}>
+                            <item.icon />
+                            <span>{item.title}</span>
+                          </Link>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    ))}
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </SidebarGroup>
+            </SidebarContent>
+            <Story />
+          </Sidebar>
+          <div className="flex-1 p-4">
+            <SidebarTrigger />
+          </div>
+        </SidebarProvider>
+      </MemoryRouter>
+    ),
+  ],
+} satisfies Meta<typeof SidebarVersionFooter>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Tag: Story = {
+  args: { version: "v0.1.0" },
+};
+
+export const CommitHash: Story = {
+  args: { version: "f3fbfa6" },
+};
+
+export const Dev: Story = {
+  args: { version: "dev" },
+};

--- a/front/src/components/SidebarVersionFooter.tsx
+++ b/front/src/components/SidebarVersionFooter.tsx
@@ -1,0 +1,27 @@
+import { SidebarFooter } from "@/components/ui";
+
+const GITHUB_REPO_URL =
+  "https://github.com/hantabaru1014/baru-reso-headless-controller";
+
+function getVersionLink(version: string): string {
+  if (version === "dev") return GITHUB_REPO_URL;
+  if (/^v\d/.test(version)) return `${GITHUB_REPO_URL}/releases/tag/${version}`;
+  return `${GITHUB_REPO_URL}/commit/${version}`;
+}
+
+export function SidebarVersionFooter({ version }: { version: string }) {
+  const label = `BRHDL ${version}`;
+  return (
+    <SidebarFooter className="group-data-[collapsible=icon]:hidden">
+      <a
+        href={getVersionLink(version)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-sidebar-foreground/70 hover:text-sidebar-foreground truncate px-2 text-xs"
+        title={label}
+      >
+        {label}
+      </a>
+    </SidebarFooter>
+  );
+}

--- a/front/src/layouts/dashboard.tsx
+++ b/front/src/layouts/dashboard.tsx
@@ -18,6 +18,7 @@ import {
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { cn } from "@/libs/cssUtils";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { SidebarVersionFooter } from "@/components/SidebarVersionFooter";
 import { UserMenuDropdown } from "@/components/UserMenuDropdown";
 
 const navigation = [
@@ -91,6 +92,7 @@ function AppSidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
+      <SidebarVersionFooter version={__APP_VERSION__} />
     </Sidebar>
   );
 }

--- a/front/src/vite-env.d.ts
+++ b/front/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,7 +1,21 @@
 import path from "path"
+import { execSync } from "child_process"
 import tailwindcss from "@tailwindcss/vite"
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+
+function resolveAppVersion(): string {
+  if (process.env.VITE_APP_VERSION) {
+    return process.env.VITE_APP_VERSION;
+  }
+  try {
+    return execSync("git rev-parse --short HEAD", { stdio: ["ignore", "pipe", "ignore"] })
+      .toString()
+      .trim();
+  } catch {
+    return "dev";
+  }
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -11,5 +25,8 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./front/src"),
     },
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(resolveAppVersion()),
   },
 });


### PR DESCRIPTION
## Summary
- サイドバー下端にバージョン表記 (`BRHDL <version>`) を追加し、リンクで GitHub の対応リソースに飛べるようにした
- バージョンはビルド時に解決: `VITE_APP_VERSION` env → `git rev-parse --short HEAD` → `"dev"` の順でフォールバック
- release workflow で `VITE_APP_VERSION` に release tag を渡すよう設定

## Test plan
- [ ] `pnpm storybook` で `components/SidebarVersionFooter` の各 Story (Tag / CommitHash / Dev) を確認
- [ ] tag: `releases/tag/<tag>`, hash: `commit/<hash>`, dev: repo root にリンクされること
- [ ] サイドバー折りたたみ時に非表示になること