### PR TITLE
fix(front): 一覧のページネーションで2ページ目以降に遷移できない問題を修正

### DIFF
--- a/front/src/components/HeadlessAccountList.tsx
+++ b/front/src/components/HeadlessAccountList.tsx
@@ -332,8 +332,9 @@ function StorageInfoTip({ accountId }: { accountId: string }) {
 }
 
 export default function HeadlessAccountList() {
-  const { pageIndex, pageSize, setPageIndex, setPageSize, syncFromServer } =
-    usePaginationState({ defaultPageSize: 20 });
+  const { pageIndex, pageSize, setPageIndex, setPageSize } = usePaginationState(
+    { defaultPageSize: 20 },
+  );
   const currentGroupId = useAtomValue(currentGroupIdAtom);
   const { data, isPending, refetch } = useQuery(
     listHeadlessAccounts,
@@ -346,12 +347,6 @@ export default function HeadlessAccountList() {
   const { hasPermission, groupsWithPermission } = usePermissions();
   const canCreate =
     groupsWithPermission(PERMISSION_KEYS.ACCOUNT_WRITE).length > 0;
-
-  useEffect(() => {
-    if (data?.page) {
-      syncFromServer(data.page.pageIndex, data.page.pageSize);
-    }
-  }, [data?.page, syncFromServer]);
 
   const { mutateAsync: mutateDeleteAccount, isPending: isPendingDelete } =
     useMutation(deleteHeadlessAccount);

--- a/front/src/components/HostList.tsx
+++ b/front/src/components/HostList.tsx
@@ -10,7 +10,6 @@ import { usePaginationState } from "../hooks/usePaginationState";
 import { useDefaultGroupId } from "../hooks/useDefaultGroupId";
 import { useAtomValue } from "jotai";
 import { currentGroupIdAtom } from "../atoms/currentGroupAtom";
-import { useEffect } from "react";
 import {
   Dialog,
   DialogContent,
@@ -29,7 +28,7 @@ import { ChevronDown } from "lucide-react";
 import { useNavigate } from "react-router";
 import { hostStatusToLabel } from "../libs/hostUtils";
 import { RefetchButton } from "./base/RefetchButton";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -312,8 +311,9 @@ const columns: ColumnDef<HeadlessHost>[] = [
 ];
 
 export default function HostList() {
-  const { pageIndex, pageSize, setPageIndex, setPageSize, syncFromServer } =
-    usePaginationState({ defaultPageSize: 20 });
+  const { pageIndex, pageSize, setPageIndex, setPageSize } = usePaginationState(
+    { defaultPageSize: 20 },
+  );
   const currentGroupId = useAtomValue(currentGroupIdAtom);
   const { data, isPending, refetch } = useQuery(
     listHeadlessHost,
@@ -328,12 +328,6 @@ export default function HostList() {
   const { groupsWithPermission } = usePermissions();
   const canStartHost =
     groupsWithPermission(PERMISSION_KEYS.HOST_WRITE).length > 0;
-
-  useEffect(() => {
-    if (data?.page) {
-      syncFromServer(data.page.pageIndex, data.page.pageSize);
-    }
-  }, [data?.page, syncFromServer]);
 
   return (
     <div className="space-y-4">

--- a/front/src/components/ScheduledOperationList.tsx
+++ b/front/src/components/ScheduledOperationList.tsx
@@ -9,7 +9,7 @@ import {
   ScheduledOperationStatus,
 } from "../../pbgen/hdlctrl/v1/controller_pb";
 import { Button } from "./ui/button";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { Link } from "react-router";
 import { ColumnDef } from "@tanstack/react-table";
 import { DataTable } from "./base";
@@ -56,11 +56,12 @@ const operationCaseToKind = (
 };
 
 export default function ScheduledOperationList({ sessionId }: Props) {
-  const { pageIndex, pageSize, setPageIndex, setPageSize, syncFromServer } =
-    usePaginationState({
+  const { pageIndex, pageSize, setPageIndex, setPageSize } = usePaginationState(
+    {
       defaultPageSize: 20,
       paramPrefix: sessionId ? "scheduledOps" : "",
-    });
+    },
+  );
 
   const currentGroupId = useAtomValue(currentGroupIdAtom);
 
@@ -75,12 +76,6 @@ export default function ScheduledOperationList({ sessionId }: Props) {
     },
     { placeholderData: keepPreviousData },
   );
-
-  useEffect(() => {
-    if (data?.page) {
-      syncFromServer(data.page.pageIndex, data.page.pageSize);
-    }
-  }, [data?.page, syncFromServer]);
 
   const { mutateAsync: cancelMutate, isPending: isCancelPending } = useMutation(
     cancelScheduledSessionOperation,

--- a/front/src/components/SessionList.tsx
+++ b/front/src/components/SessionList.tsx
@@ -8,7 +8,7 @@ import { AccessLevels } from "../constants";
 import { RefetchButton } from "./base/RefetchButton";
 import { sessionStatusToLabel } from "../libs/sessionUtils";
 import { SelectField } from "./base/SelectField";
-import { ReactNode, useEffect, useMemo, useState } from "react";
+import { ReactNode, useMemo, useState } from "react";
 import { Session, SessionStatus } from "../../pbgen/hdlctrl/v1/controller_pb";
 import { ColumnDef } from "@tanstack/react-table";
 import { DataTable } from "./base";
@@ -36,8 +36,9 @@ export default function SessionList() {
   const { data: hosts } = useQuery(listHeadlessHost, {
     groupId: currentGroupId ?? undefined,
   });
-  const { pageIndex, pageSize, setPageIndex, setPageSize, syncFromServer } =
-    usePaginationState({ defaultPageSize: 20 });
+  const { pageIndex, pageSize, setPageIndex, setPageSize } = usePaginationState(
+    { defaultPageSize: 20 },
+  );
   const { data, isPending, refetch } = useQuery(
     searchSessions,
     {
@@ -54,12 +55,6 @@ export default function SessionList() {
   const { groupsWithPermission } = usePermissions();
   const canCreate =
     groupsWithPermission(PERMISSION_KEYS.SESSION_WRITE).length > 0;
-
-  useEffect(() => {
-    if (data?.page) {
-      syncFromServer(data.page.pageIndex, data.page.pageSize);
-    }
-  }, [data?.page, syncFromServer]);
 
   const columns: ColumnDef<Session>[] = useMemo(() => {
     const hostNameMap =

--- a/front/src/hooks/usePaginationState.ts
+++ b/front/src/hooks/usePaginationState.ts
@@ -22,12 +22,6 @@ export type UsePaginationStateReturn = {
   setPageIndex: (n: number) => void;
   /** Setting page size always resets pageIndex to 0. */
   setPageSize: (n: number) => void;
-  /**
-   * Sync URL with the server's effective values.
-   * Useful when the server clamps/adjusts the requested values.
-   * No-op when the URL already matches.
-   */
-  syncFromServer: (serverPageIndex: number, serverPageSize: number) => void;
 };
 
 export const DEFAULT_PAGE_SIZE = 20;
@@ -125,55 +119,11 @@ export function usePaginationState(
     ],
   );
 
-  const syncFromServer = useCallback(
-    (serverPageIndex: number, serverPageSize: number) => {
-      const serverSafePageIndex = Math.max(0, Math.floor(serverPageIndex));
-      const serverSafePageSize = pageSizeOptions.includes(serverPageSize)
-        ? serverPageSize
-        : defaultPageSize;
-
-      if (
-        serverSafePageIndex === pageIndex &&
-        serverSafePageSize === pageSize
-      ) {
-        return;
-      }
-
-      setSearchParams(
-        (prev) => {
-          const next = new URLSearchParams(prev);
-          if (serverSafePageIndex === 0) {
-            next.delete(pageParam);
-          } else {
-            next.set(pageParam, String(serverSafePageIndex + 1));
-          }
-          if (serverSafePageSize === defaultPageSize) {
-            next.delete(pageSizeParam);
-          } else {
-            next.set(pageSizeParam, String(serverSafePageSize));
-          }
-          return next;
-        },
-        { replace: true },
-      );
-    },
-    [
-      setSearchParams,
-      pageParam,
-      pageSizeParam,
-      pageIndex,
-      pageSize,
-      pageSizeOptions,
-      defaultPageSize,
-    ],
-  );
-
   return {
     pageIndex,
     pageSize,
     pageSizeOptions,
     setPageIndex,
     setPageSize,
-    syncFromServer,
   };
 }


### PR DESCRIPTION
## 概要

セッション一覧など DataTable ベースの一覧で、「次へ」を押しても 2 ページ目以降に遷移できないバグを修正する。

## 原因

各 consumer で `data.page` を deps に取る `useEffect` から `syncFromServer` を呼んでいたが、`@tanstack/react-query` v5 の `placeholderData: keepPreviousData` は placeholder 期間中も `data` の参照が変わるため、ページ切替直後に「サーバが返した旧ページの値」で URL を上書きしていた。

## 対応

`syncFromServer` は本来「サーバが pageSize を clamp した場合に URL を実際の値へ同期する」ためのものだったが、クライアント側の URL parse で pageSize は既に `[20, 50, 100]` にホワイトリスト済みで clamp 条件が発火せず、実質デッドコードだった。フックから丸ごと削除し、4 つの一覧 consumer から `useEffect` ごと外した。

## Test plan
- [ ] `/sessions` (21 件, デフォルト 20/ページ) で「次へ」→ `?page=2` に遷移し表示も切り替わる
- [ ] 「前へ」で `/sessions` に戻る
- [ ] ホスト / ヘッドレスアカウント / 予約操作 の一覧も同様