### PR TITLE
docs: README を刷新して開発ガイドを docs に分離

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,85 +1,66 @@
 # baru-reso-headless-controller
 
-[baru-reso-headless-container](https://github.com/hantabaru1014/baru-reso-headless-container) の管理ダッシュボードWebアプリ
+A self-hosted control plane for [baru-reso-headless-container](https://github.com/hantabaru1014/baru-reso-headless-container) that turns Resonite headless hosting into a multi-instance, multi-user service.
 
-ステータス:
-(WIP) 開発の初期段階なのでいろいろ破壊します  
-とりあえず最低限コンテナのマネジメントとセッション管理ができる
+The official headless client is a console application: one terminal per instance, hand-edited config files, and access limited to whoever can reach the shell. This controller instead runs headless instances as Docker containers, so you and your team can spin up, operate, upgrade, and shut down any number of them from the browser — with group-based access control deciding who can manage what.
 
-## 動作環境
-- `network: host` が利用できるdocker
-- 対応CPU archはAMD64 or ARM64
+## Features
+
+- **Host management**: start / stop / restart / delete headless containers, view their logs
+  - Detects and pulls new container images automatically, and can upgrade running hosts on its own
+- **Session management**: create / stop sessions, edit session parameters, invite / kick / ban users, change user roles
+  - Schedule session operations with time- or condition-based triggers
+  - Save worlds and download world binaries
+- **Headless account management**: credentials, storage usage, friend requests and messaging
+- **Access control**: group-based RBAC — see [docs/permissions.md](docs/permissions.md)
+- **Log aggregation**: container logs are collected into PostgreSQL and browsable from the dashboard
+- **Live updates**: server-side push keeps the dashboard in sync without reloading
+
+## Requirements
+
+- Docker with `network: host` available
+- CPU arch: AMD64 or ARM64
+- Access to a baru-reso-headless-container image registry
 
 ## Setup
-以下はcontrollerとPostgresSQLをdocker-composeで立ち上げる場合の手順。  
-k8sで立ち上げたり、既存のpostgresに接続したい場合はsetup.shの実行まで行ったらcomposeファイルや.envを見て良しなにやってください。  
-また、baru-reso-headless-containerのdockerイメージのレジストリにアクセスできる状態である必要があります。
 
-- 空のディレクトリを用意してカレントディレクトリとする
-- 必要なファイルのダウンロード、`.env` のセットアップ、DBの起動とマイグレーションを行う
-  ```sh
-  sh <(curl -s https://raw.githubusercontent.com/hantabaru1014/baru-reso-headless-controller/refs/heads/main/scripts/setup.sh)
-  ```
-  このスクリプトは以下を自動的に実行します：
-  - 必要なファイルのダウンロード（docker-compose.yml、brhcliなど）
-  - `.env` ファイルの生成
-  - データベースの起動
-  - データベースマイグレーションの実行
-  - fluentbitユーザーのパスワード設定
-- 管理者ユーザの作成
-  ```sh
-  ./brhcli user create <メールアドレス> <パスワード> <Resonite UserID>
-  ```
-- 本体を起動
-  ```sh
-  docker compose up -d
-  ```
-- 完了。 http://localhost:8014/ でアクセスできます。
-  - ポートは `.env` にある `HOST` 環境変数で設定可能
-  - 認証認可部分はまだちゃんと作ってないのでエンドポイント自体を何らかの信頼できる方法で保護してください(おすすめ: CloudFlare Zero Trust)
+The steps below bring up the controller, PostgreSQL, and friends with docker compose.
+If you want to run on k8s or connect to an existing PostgreSQL, run setup.sh first and then adjust the compose files and `.env`.
 
-## 既存環境のアップグレード
+1. Create an empty directory and cd into it
+2. Run the setup script
+   ```sh
+   sh <(curl -s https://raw.githubusercontent.com/hantabaru1014/baru-reso-headless-controller/refs/heads/main/scripts/setup.sh)
+   ```
+   The script takes care of:
+   - Downloading the required files (docker-compose.yml, brhcli, etc.)
+   - Generating the `.env` file
+   - Starting PostgreSQL / fluent-bit / RustFS
+   - Running database migrations
+3. Create an admin user
+   ```sh
+   ./brhcli user create <email> <password> <Resonite UserID>
+   ```
+4. Start the controller
+   ```sh
+   docker compose up -d
+   ```
+5. Done. The dashboard is available at http://localhost:8014/
+   - The port can be changed via the `HOST` variable in `.env`
+   - If you expose it to the internet, protect the endpoint with a reverse proxy, Cloudflare Zero Trust, or similar
 
-既に稼働中の環境で最新版にアップグレードする場合、以下のコマンドを実行してください：
+## Upgrading
+
+To upgrade a running deployment to the latest version, run the following in the directory you used for setup:
 
 ```sh
 sh <(curl -s https://raw.githubusercontent.com/hantabaru1014/baru-reso-headless-controller/refs/heads/main/scripts/auto-upgrade.sh)
 ```
 
-このスクリプトは以下を自動的に実行します：
-- 最新のdocker-compose.yml、brhcli等のダウンロード
-- データベースマイグレーションの実行
-- データベースの状態に応じたFluentBit設定
-- fluentdコンテナの再起動
+It downloads the latest compose files, images, and brhcli, runs database migrations, appends any newly required settings to `.env`, and recreates the containers.
+Backing up important data before upgrading is recommended.
 
-**注意事項:**
-- このスクリプトは`.env`ファイルが存在する既存環境向けです
-- 新規セットアップの場合は `setup.sh` を使用してください
-- アップグレード前に重要なデータのバックアップを推奨します
+## Documentation
 
-## 開発
-
-### テスト
-
-#### 初回セットアップ
-
-テスト用データベースの作成とマイグレーション:
-```sh
-make test.setup
-```
-このコマンドは、環境変数 `DB_URL` で指定されたデータベース名に `_test` を追加したテストデータベースを作成し、マイグレーションを実行します。
-
-#### テストの実行
-
-```sh
-make test
-```
-
-#### テストの構造
-
-- **テストデータベース**: 実際の PostgreSQL データベースを使用しますが、データベース名に `_test` サフィックスが付きます
-- **モック**: `mockgen` を使用して、外部依存である `HostConnector` インターフェースのモックを生成します
-  - Dockerコンテナを実行せずにテストできるよう、`HostConnector`のみをモック化
-  - Repository層は実際の実装を使用し、データベース操作も含めてテスト
-  - コード変更後は `make gen.mock` でmock生成が必要
-- **テストヘルパー**: `testutil/` パッケージに共通のテストユーティリティが含まれています
+- [Development guide](docs/development.md) - architecture, dev environment setup, testing
+- [Permission system](docs/permissions.md) - RBAC concepts and configuration

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,125 @@
+# 開発ガイド
+
+## アーキテクチャ
+
+| 領域 | 技術 |
+|---|---|
+| バックエンド | Go (Clean Architecture)、Connect (gRPC-Web)、Wire (DI)、sqlc |
+| フロントエンド | React + Vite、TanStack Query、Jotai、Tailwind CSS + shadcn/ui |
+| データベース | PostgreSQL (golang-migrate によるマイグレーション。app 起動時に自動実行) |
+| ストレージ | RustFS (S3互換。ワールドバイナリの保存に使用) |
+| ログ | fluent-bit 経由でコンテナログを PostgreSQL に集約 |
+
+### ディレクトリ構成
+
+```
+proto/      Protocol Buffers 定義 (proto/headless は submodule への symlink)
+pbgen/      proto から生成された Go コード (front/pbgen は TypeScript)
+domain/     ドメイン層 (エンティティ・エラー)
+usecase/    ユースケース層 (ビジネスロジック)
+adapter/    アダプタ層 (リポジトリ、RPC サービス、HostConnector)
+worker/     バックグラウンドワーカー (イベント監視、非同期 job、予約実行など)
+app/        DI 設定 (Wire)、サーバ組み立て
+cmd/        エントリポイント (server / cli)
+db/         マイグレーション・クエリ定義 (sqlc)
+lib/        インフラ・外部APIクライアント (skyfrost、blobstore など)
+config/     環境変数の読み込み
+front/      フロントエンド (React)
+```
+
+## 開発環境のセットアップ
+
+### 必要なもの
+
+- Go (バージョンは [mise.toml](../mise.toml) を参照。[mise](https://mise.jdx.dev/) の利用を推奨)
+- Node.js + pnpm
+- Docker (開発用 DB とヘッドレスコンテナの起動に使用)
+
+### 初回セットアップ
+
+```sh
+# submodule (proto 定義の参照元) を含めて clone
+git clone --recursive https://github.com/hantabaru1014/baru-reso-headless-controller.git
+cd baru-reso-headless-controller
+
+# フロントエンドの依存をインストール
+pnpm install
+
+# .env を用意 (必要な環境変数は scripts/setup.sh と config/config.go を参照)
+
+# 開発用 DB (PostgreSQL / fluent-bit / RustFS) を起動
+docker compose -f docker-compose.db.yml up -d
+
+# マイグレーションを実行 (app 起動時にも自動実行される)
+make migrate.up
+
+# 管理者ユーザを作成
+make build.cli
+./bin/brhcli user create <メールアドレス> <パスワード> <Resonite UserID>
+```
+
+### 開発サーバの起動
+
+```sh
+# フロントエンド (Vite dev server)
+pnpm dev
+
+# バックエンド (-fdev で Vite dev server にプロキシ)
+go run ./cmd/server -fdev
+```
+
+## よく使うコマンド
+
+| コマンド | 説明 |
+|---|---|
+| `make gen.proto` | protobuf コード生成 (Go / TypeScript) |
+| `make gen.wire` | DI コード生成 |
+| `make gen.sqlc` | SQL クエリコード生成 |
+| `make gen.mock` | テスト用 mock 生成 |
+| `make lint` | Go の lint (golangci-lint) |
+| `make lint.proto` | proto の format と lint |
+| `make build.cli` | CLI (`./bin/brhcli`) のビルド |
+| `make build.docker` | Docker イメージのビルド |
+| `make exec.psql` | 開発用 DB に psql で接続 |
+| `pnpm lint` / `pnpm lint:fix` | フロントエンドの lint |
+| `pnpm typecheck` | TypeScript の型チェック |
+| `pnpm storybook` | Storybook の起動 |
+
+スキーマ (proto / SQL / Wire 設定) を変更したら対応する `make gen.*` を実行してください。
+
+### データベースマイグレーション
+
+マイグレーションファイルの作成:
+
+```sh
+go tool migrate create -ext sql -dir db/migrations <file_name>
+```
+
+適用は `make migrate.up` (開発用 DB とテスト用 DB の両方に適用)、または app 起動時の自動実行で行われます。
+
+## テスト
+
+### 初回セットアップ
+
+テスト用データベースの作成とマイグレーション:
+
+```sh
+make test.setup
+```
+
+このコマンドは、環境変数 `DB_URL` で指定されたデータベース名に `_test` を追加したテストデータベースを作成し、マイグレーションを実行します。
+
+### テストの実行
+
+```sh
+make test
+```
+
+### テストの構造
+
+- **テストデータベース**: 実際の PostgreSQL データベースを使用しますが、データベース名に `_test` サフィックスが付きます
+- **モック**: `mockgen` を使用して、外部依存 (`HostConnector`、skyfrost、blobstore など) のモックを生成します
+  - Docker コンテナを実行せずにテストできるよう、外部依存のみをモック化
+  - Repository 層は実際の実装を使用し、データベース操作も含めてテスト
+  - モック対象のインターフェース変更後は `make gen.mock` で再生成が必要
+- **テストヘルパー**: `testutil/` パッケージに共通のテストユーティリティが含まれています


### PR DESCRIPTION
## 概要
- 実装から乖離していた README を英語で全面的に書き直し
- 冒頭は公式 headless client との対比で multi-instance / multi-user を訴求する構成に
- 開発者向けの内容は docs/development.md に分離

## 補足
- セットアップ / アップグレード手順は scripts/setup.sh・auto-upgrade.sh の実挙動を確認して記載