### PR TITLE
fix: make migrate.up / test.setup が失敗する問題を修正しテストの分離を強化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,16 +44,26 @@ gen.mock:
 	go tool mockgen -source=lib/blobstore/blobstore.go -destination=lib/blobstore/mock/mock_client.go -package=mock
 	@echo "Mock generation complete!"
 
+# golang-migrate の CLI は DB ドライバを build tag で選ぶ作りで、タグ無しでビルドすると
+# 1 つも登録されない。そのため `go tool migrate ... up` は "unknown driver postgres" で
+# 失敗する。DB に接続するサブコマンド用に postgres タグ付きのバイナリを用意する。
+# (migration ファイルの新規作成は DB に繋がないので `go tool migrate create` のままでよい)
+BIN_MIGRATE := ./bin/migrate
+
+.PHONY: build.migrate
+build.migrate:
+	@go build -tags postgres -o $(BIN_MIGRATE) github.com/golang-migrate/migrate/v4/cmd/migrate
+
 .PHONY: migrate.up
-migrate.up:
-	@go tool migrate -path db/migrations -database "$(DB_URL)" up
+migrate.up: build.migrate
+	@$(BIN_MIGRATE) -path db/migrations -database "$(DB_URL)" up
 	@DB_NAME=$$(echo "$(DB_URL)" | sed 's/.*\/\([^?]*\).*/\1/'); \
 	TEST_DB_NAME=$${DB_NAME}_test; \
 	TEST_DB_URL=$$(echo "$(DB_URL)" | sed "s/$$DB_NAME/$$TEST_DB_NAME/"); \
-	go tool migrate -path db/migrations -database "$$TEST_DB_URL" up
+	$(BIN_MIGRATE) -path db/migrations -database "$$TEST_DB_URL" up
 
 .PHONY: test.setup
-test.setup:
+test.setup: build.migrate
 	@echo "Creating test database..."
 	@DB_NAME=$$(echo "$(DB_URL)" | sed 's/.*\/\([^?]*\).*/\1/'); \
 	TEST_DB_NAME=$${DB_NAME}_test; \
@@ -64,11 +74,14 @@ test.setup:
 	(echo "Creating test database $$TEST_DB_NAME..." && \
 	docker compose -f docker-compose.db.yml exec -T db psql -U postgres -d postgres -c "CREATE DATABASE $$TEST_DB_NAME"); \
 	echo "Running migrations..."; \
-	go tool migrate -path db/migrations -database "$$TEST_DB_URL" up
+	$(BIN_MIGRATE) -path db/migrations -database "$$TEST_DB_URL" up
 
+# 全パッケージのテストが 1 つのテスト DB を共有し、各テストの開始時に TRUNCATE で
+# クリアする。パッケージを並列実行すると互いの TRUNCATE と行の投入が競合して
+# deadlock / duplicate key で落ちるため、パッケージ単位では直列に実行する (-p 1)。
 .PHONY: test
 test:
-	go tool gotestsum --format dots -- ./...
+	go tool gotestsum --format dots -- -p 1 ./...
 
 .PHONY: lint
 lint:

--- a/docs/development.md
+++ b/docs/development.md
@@ -114,6 +114,13 @@ go tool migrate create -ext sql -dir db/migrations <file_name>
 
 適用は `make migrate.up` (開発用 DB とテスト用 DB の両方に適用)、または app 起動時の自動実行で行われます。
 
+> [!NOTE]
+> golang-migrate の CLI は DB ドライバを build tag で選ぶため、`go tool migrate` は
+> DB に接続できません (`unknown driver postgres`)。`make migrate.up` / `make test.setup` は
+> `make build.migrate` で `./bin/migrate` を postgres タグ付きでビルドして使います。
+> 手動で `up` / `down` を叩くときも `./bin/migrate` を使ってください
+> (ファイル作成は DB に繋がないので `go tool migrate create` で問題ありません)。
+
 ## テスト
 
 ### 初回セットアップ
@@ -135,6 +142,9 @@ make test
 ### テストの構造
 
 - **テストデータベース**: 実際の PostgreSQL データベースを使用しますが、データベース名に `_test` サフィックスが付きます
+  - 全パッケージがこの 1 つの DB を共有し、各テストの開始時に `testutil.CleanupTables` が TRUNCATE でクリアします
+  - そのため `make test` はパッケージを直列実行します (`-p 1`)。`go test ./...` を直に叩くとパッケージが並列に走り、互いのデータを消し合って不安定になります
+  - 同じ理由で、テストの実行中に別のシェルでテストを走らせないでください
 - **モック**: `mockgen` を使用して、外部依存 (`HostConnector`、skyfrost、blobstore など) のモックを生成します
   - Docker コンテナを実行せずにテストできるよう、外部依存のみをモック化
   - Repository 層は実際の実装を使用し、データベース操作も含めてテスト

--- a/testutil/db.go
+++ b/testutil/db.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/golang-migrate/migrate/v4"
@@ -115,11 +116,15 @@ func CleanupTables(t *testing.T, pool *pgxpool.Pool) {
 		t.Fatalf("error iterating tables: %v", err)
 	}
 
-	// Truncate all tables in a single transaction for better performance
-	for _, table := range tables {
-		truncateQuery := fmt.Sprintf("TRUNCATE TABLE %s CASCADE", table)
+	// テーブルごとに TRUNCATE を発行するとロックの取得順がテスト間で食い違い、
+	// 同じテスト DB を共有する別テストと deadlock しやすい。1 文にまとめれば
+	// PostgreSQL 側が全テーブルのロックをまとめて取るのでこの競合は起きない。
+	if len(tables) > 0 {
+		truncateQuery := fmt.Sprintf("TRUNCATE TABLE %s CASCADE", strings.Join(tables, ", "))
+		// ここを warning で握りつぶすと行が残ったまま次のテストが走り、無関係な
+		// duplicate key / FK violation として現れて原因が追えなくなる。即座に落とす。
 		if _, err := pool.Exec(t.Context(), truncateQuery); err != nil {
-			t.Logf("warning: failed to truncate table %s: %v", table, err)
+			t.Fatalf("failed to truncate tables: %v", err)
 		}
 	}
 
@@ -128,6 +133,6 @@ func CleanupTables(t *testing.T, pool *pgxpool.Pool) {
 	// は seed なので残す). CASCADE で group_members / roles も連動削除される.
 	if _, err := pool.Exec(t.Context(),
 		"DELETE FROM groups WHERE id NOT IN ('system', 'migrated-pre-permission')"); err != nil {
-		t.Logf("warning: failed to delete per-test groups: %v", err)
+		t.Fatalf("failed to delete per-test groups: %v", err)
 	}
 }


### PR DESCRIPTION
## 1. `make migrate.up` / `make test.setup` が失敗する (確認済みのバグ)

golang-migrate の CLI は DB ドライバを build tag で選ぶ作りで、タグ無しでビルドすると
1 つも登録されません。そのため `go tool migrate ... up` は必ず次で失敗していました。

```
error: failed to open database: database driver: unknown driver postgres (forgotten import?)
```

postgres タグ付きでビルドした `./bin/migrate` を使うようにしています
(`make build.migrate`)。DB に接続しない `migrate create` は `go tool migrate` のままです。

## 2. テスト DB クリーンアップの堅牢化

`CleanupTables` はテーブルごとに TRUNCATE を発行し、失敗を `t.Logf` の warning に
していました。これだと deadlock で TRUNCATE が失敗しても素通りし、行が残ったまま
次のテストが走って、無関係な `duplicate key ... users_pkey` として現れます。実際に
この症状で「テストスイートが壊れている」ように見える状況が起きました。

- TRUNCATE を 1 文にまとめる (PostgreSQL 側が全テーブルのロックをまとめて取るので
  ロック順の食い違いが起きない)
- 失敗したら握りつぶさず即座に落とす

## 3. `make test` のパッケージ直列実行

全パッケージが 1 つのテスト DB を共有し、各テストが開始時に TRUNCATE します。
パッケージが並列に走ると互いのデータを消し合うため `-p 1` を付けています。

## 検証

- 変更前: `make test.setup` は 100% 失敗 / 変更後: テスト DB を drop した状態から成功
- `make build.migrate` のバイナリで main のマイグレーションが最後まで適用できることを
  使い捨て DB で確認
- `make test`: 451 tests / 0 failures
- `go vet` / `gofmt` / `golangci-lint run ./testutil/...` いずれもクリーン

なお 2 については、単一の `go test ./...` (パッケージ並列) だけでは手元で deadlock を
再現できませんでした。再現したのは複数の `go test` プロセスが同時に同じ DB を
使ったときです。今回の変更は原因の除去と、失敗したときに原因が分かる形にすることが
主眼です。
